### PR TITLE
Basilisk v14

### DIFF
--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -461,6 +461,10 @@
                 "name": "OnFinality node"
             }
         ],
+        "types": {
+            "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/basilisk.json",
+            "overridesCommon": true
+        },
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Basilisk.svg",
         "addressPrefix": 10041
     },

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -669,7 +669,7 @@
     {
         "chainId": "8bf43860c54d5520fd0ec7afa15c2912a1d3b0e4cf132a5838a83b171dad4c70",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Basilisk",
+        "name": "Basilisk (Wrong Genesis)",
         "assets": [
             {
                 "assetId": 0,
@@ -687,6 +687,10 @@
                 "name": "OnFinality node"
             }
         ],
+        "types": {
+            "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/basilisk.json",
+            "overridesCommon": true
+        },
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Basilisk.svg",
         "addressPrefix": 42
     },

--- a/chains/v2/types/basilisk.json
+++ b/chains/v2/types/basilisk.json
@@ -1,0 +1,16 @@
+{
+  "runtime_id": 25,
+  "types": {
+      "Balance": "u128",
+      "Index": "u32",
+      "Phase": "frame_system.Phase",
+      "Address": "sp_core.crypto.AccountId32",
+      "ExtrinsicSignature": "sp_runtime.MultiSignature",
+      "ParaId": "polkadot_parachain.primitives.Id",
+      "basilisk_runtime.Event": "GenericEvent",
+      "basilisk_runtime.Call": "GenericCall",
+      "sp_core.crypto.AccountId32": "GenericAccountId",
+      "pallet_identity.types.Data": "Data"
+  },
+  "versioning": []
+}


### PR DESCRIPTION
To note moments:
* Despite v14 metadata,`MultiAddress` is not used. They `Address` type correponds to the `AccountId32`
![image](https://user-images.githubusercontent.com/70131744/144762858-13aac77f-4cf6-4165-86bf-6ec2a1e7c568.png)
![image](https://user-images.githubusercontent.com/70131744/144762864-7fbfc4c6-c434-446f-8484-eb3a75a21030.png)
