### PR TITLE
Fix naming for QUARTZ network

### DIFF
--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -902,7 +902,7 @@
     {
         "chainId": "cd4d732201ebe5d6b014edda071c4203e16867305332301dc8d092044b28e554",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-        "name": "Quartz",
+        "name": "QUARTZ",
         "assets": [
             {
                 "assetId": 0,
@@ -913,15 +913,15 @@
         "nodes": [
             {
                 "url": "wss://quartz.unique.network",
-                "name": "Unic node"
+                "name": "Unique node"
             },
             {
                 "url": "wss://eu-ws-quartz.unique.network",
-                "name": "Unic europe node"
+                "name": "Unique Europe node"
             },
             {
                 "url": "wss://us-ws-quartz.unique.network",
-                "name": "Unic US node"
+                "name": "Unique US node"
             }
         ],
         "types": {


### PR DESCRIPTION
QUARTZ network and nodes naming was fixed.

Signed\-off\-by: Stepan Lavrentev <lawrentievsv@gmail.com>