### PR TITLE
Adding vsKSM. And DOT for Acala

### DIFF
--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -523,6 +523,19 @@
                     "existentialDeposit": "1000000000000",
                     "transfersEnabled": true
                 }
+            },
+            {
+                "assetId": 10,
+                "symbol": "vsKSM",
+                "precision": 12,
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x00a9",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "100000000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [
@@ -858,6 +871,19 @@
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KUSD.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x0302",
+                    "currencyIdType": "node_primitives.currency.CurrencyId",
+                    "existentialDeposit": "100000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 6,
+                "symbol": "vsKSM",
+                "precision": 12,
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0404",
                     "currencyIdType": "node_primitives.currency.CurrencyId",
                     "existentialDeposit": "100000000",
                     "transfersEnabled": true
@@ -1406,7 +1432,7 @@
             },
             {
                 "assetId": 1,
-                "symbol": "LDOT",
+                "symbol": "LСDOT",
                 "precision": 10,
                 "priceId": "polkadot",
                 "type": "orml",
@@ -1414,7 +1440,7 @@
                 "typeExtras": {
                     "currencyIdScale": "0x040d000000",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "100000000",
+                    "existentialDeposit": "10000000000",
                     "transfersEnabled": false
                 }
             },
@@ -1428,7 +1454,21 @@
                 "typeExtras": {
                     "currencyIdScale": "0x0001",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "100000000000",
+                    "existentialDeposit": "10000000000",
+                    "transfersEnabled": false
+                }
+            },
+            {
+                "assetId": 3,
+                "symbol": "DOT",
+                "precision": 10,
+                "priceId": "tether",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0002",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "10000000000",
                     "transfersEnabled": false
                 }
             }

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -1432,7 +1432,7 @@
             },
             {
                 "assetId": 1,
-                "symbol": "LCDOT",
+                "symbol": "LDOT",
                 "precision": 10,
                 "priceId": "polkadot",
                 "type": "orml",
@@ -1474,7 +1474,7 @@
             },
             {
                 "assetId": 4,
-                "symbol": "LDOT",
+                "symbol": "LCDOT",
                 "precision": 10,
                 "priceId": "polkadot",
                 "type": "orml",

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -1436,7 +1436,7 @@
                 "precision": 10,
                 "priceId": "polkadot",
                 "type": "orml",
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Polkadot.svg",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x040d000000",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
@@ -1464,7 +1464,7 @@
                 "precision": 10,
                 "priceId": "tether",
                 "type": "orml",
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Polkadot.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x0002",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -1440,7 +1440,7 @@
                 "typeExtras": {
                     "currencyIdScale": "0x040d000000",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "10000000000",
+                    "existentialDeposit": "100000000",
                     "transfersEnabled": false
                 }
             },
@@ -1454,7 +1454,7 @@
                 "typeExtras": {
                     "currencyIdScale": "0x0001",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "10000000000",
+                    "existentialDeposit": "100000000000",
                     "transfersEnabled": false
                 }
             },
@@ -1468,7 +1468,7 @@
                 "typeExtras": {
                     "currencyIdScale": "0x0002",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "10000000000",
+                    "existentialDeposit": "100000000",
                     "transfersEnabled": false
                 }
             }

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -1432,15 +1432,15 @@
             },
             {
                 "assetId": 1,
-                "symbol": "LСDOT",
+                "symbol": "LCDOT",
                 "precision": 10,
                 "priceId": "polkadot",
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x040d000000",
+                    "currencyIdScale": "0x0003",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "100000000",
+                    "existentialDeposit": "500000000",
                     "transfersEnabled": false
                 }
             },
@@ -1462,11 +1462,25 @@
                 "assetId": 3,
                 "symbol": "DOT",
                 "precision": 10,
-                "priceId": "tether",
+                "priceId": "polkadot",
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Polkadot.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x0002",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "100000000",
+                    "transfersEnabled": false
+                }
+            },
+            {
+                "assetId": 4,
+                "symbol": "LDOT",
+                "precision": 10,
+                "priceId": "polkadot",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x040d000000",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
                     "existentialDeposit": "100000000",
                     "transfersEnabled": false


### PR DESCRIPTION
This pr is adding:

- vsKSM for Bifrost
- vsKSM for Karura
- DOT for Acala

Changing:
- LCDOT name
- LCDOT icon

Proofs:
- vsKSM in bifrost:
<img width="809" alt="Screenshot 2022-02-03 at 13 28 44" src="https://user-images.githubusercontent.com/40560660/152333152-a9216d79-dc8f-49ae-8bd0-648c58c88351.png">

- vsKSM in Karura:
<img width="734" alt="Screenshot 2022-02-03 at 14 24 41" src="https://user-images.githubusercontent.com/40560660/152334127-dcf97d5a-c672-430a-a470-d990220e60af.png">

- DOT in Acala:
<img width="685" alt="Screenshot 2022-02-03 at 14 27 35" src="https://user-images.githubusercontent.com/40560660/152334507-77743360-ca0c-46ed-b00c-86fd8b596fe1.png">