### PR TITLE
Fix DOT ED in Acala Mandala

### DIFF
--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -1555,7 +1555,7 @@
                 "typeExtras": {
                     "currencyIdScale": "0x0002",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "100000000"
+                    "existentialDeposit": "1000000"
                 }
             }
         ],


### PR DESCRIPTION
currencyIdScale = 0x0002

1) millicent(currencyId) = cent(currencyId) / 1000
Proof: https://github.com/AcalaNetwork/Acala/blob/master/runtime/common/src/lib.rs#L174

2) cent(currencyId) = dollar(currencyId) / 100

3) dollar(currencyId) = 10^decimals = 10^10
Proof: https://github.com/AcalaNetwork/Acala/blob/master/runtime/common/src/lib.rs#L166

4) DOT.decimals = 10
Proof: https://github.com/AcalaNetwork/Acala/blob/master/primitives/src/currency.rs#L186

ED(DOT) = 10 * millicent(currencyId) = 10 * 10^-3 * 10^-2 * 10^10 = 10^6
Proof: https://github.com/AcalaNetwork/Acala/blob/master/runtime/mandala/src/lib.rs#L779