### PR TITLE
Enable Acala transfers on prod

### DIFF
--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -1179,7 +1179,7 @@
                     "currencyIdScale": "0x0003",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
                     "existentialDeposit": "500000000",
-                    "transfersEnabled": false
+                    "transfersEnabled": true
                 }
             },
             {
@@ -1193,7 +1193,7 @@
                     "currencyIdScale": "0x0001",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
                     "existentialDeposit": "100000000000",
-                    "transfersEnabled": false
+                    "transfersEnabled": true
                 }
             },
             {
@@ -1207,7 +1207,7 @@
                     "currencyIdScale": "0x0002",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
                     "existentialDeposit": "100000000",
-                    "transfersEnabled": false
+                    "transfersEnabled": true
                 }
             },
             {
@@ -1220,7 +1220,7 @@
                     "currencyIdScale": "0x040d000000",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
                     "existentialDeposit": "100000000",
-                    "transfersEnabled": false
+                    "transfersEnabled": true
                 }
             }
         ],


### PR DESCRIPTION
DOT transfer:
https://acala.subscan.io/extrinsic/0x52e62a7341bfb872505a7177be3302ae6295f00a8803e9718adb917d0b721398

Also Valentin provide proofs:
![image](https://user-images.githubusercontent.com/40560660/152757467-2bb18c26-b4ff-40a8-be14-dc855d1bf8cf.png)
