### PR TITLE
Fix trigger for CI

### DIFF
--- a/.github/workflows/update_readme.yaml
+++ b/.github/workflows/update_readme.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           files: chains/v2/chains.json
       - name: Job is fail
-        if: steps.changed-files.outputs.only_changed == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: exit 1
 
   build:


### PR DESCRIPTION
This PR is fixing trigger how CI is checking changed files
Behaviour before:
- CI triggered only if changed one file "chains/v2/chains.json"

Behaviour now:
- CI will trigger if changed any files and the "chains/v2/chains.json"
- CI won't trigger if "chains/v2/chains.json" not change