### PR TITLE
Promote SubID and Statescan to prod

### DIFF
--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -1502,10 +1502,6 @@
                 "extrinsic": "https://parallel.subscan.io/extrinsic/{hash}",
                 "account": "https://parallel.subscan.io/account/{address}",
                 "event": null
-            },
-            {
-                "name": "Sub.ID",
-                "account": "https://sub.id/{address}"
             }
         ],
         "types": {

--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -37,6 +37,10 @@
                 "extrinsic": "https://polkascan.io/polkadot/extrinsic/{hash}",
                 "account": "https://polkascan.io/polkadot/account/{address}",
                 "event": "https://polkascan.io/polkadot/event/{event}"
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "color": "linear-gradient(315deg, #D43079 0%, #F93C90 100%)",
@@ -102,6 +106,10 @@
                 "extrinsic": "https://polkascan.io/kusama/extrinsic/{hash}",
                 "account": "https://polkascan.io/kusama/account/{address}",
                 "event": "https://polkascan.io/kusama/event/{event}"
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "color": "linear-gradient(315deg, #000000 0%, #3F3F3F 100%)",
@@ -286,6 +294,16 @@
                 "extrinsic": "https://statemine.subscan.io/extrinsic/{hash}",
                 "account": "https://statemine.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Statescan",
+                "extrinsic": "https://statemine.statescan.io/extrinsic/{hash}",
+                "account": "https://statemine.statescan.io/account/{address}",
+                "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -541,6 +559,10 @@
                 "extrinsic": "https://karura.subscan.io/extrinsic/{hash}",
                 "account": "https://karura.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "externalApi": {
@@ -731,6 +753,10 @@
                 "extrinsic": "https://shiden.subscan.io/extrinsic/{hash}",
                 "account": "https://shiden.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "externalApi": {
@@ -866,6 +892,10 @@
                 "extrinsic": "https://bifrost.subscan.io/extrinsic/{hash}",
                 "account": "https://bifrost.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "externalApi": {
@@ -897,6 +927,12 @@
             {
                 "url": "wss://rpc-01.basilisk.hydradx.io",
                 "name": "Hydradx node"
+            }
+        ],
+        "explorers": [
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -935,6 +971,10 @@
                 "extrinsic": "https://altair.subscan.io/extrinsic/{hash}",
                 "account": "https://altair.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "externalApi": {
@@ -1029,6 +1069,10 @@
                 "extrinsic": "https://edgeware.subscan.io/extrinsic/{hash}",
                 "account": "https://edgeware.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "color": "linear-gradient(315deg, #000000 0%, #3F3F3F 100%)",
@@ -1063,6 +1107,10 @@
                 "extrinsic": "https://khala.subscan.io/extrinsic/{hash}",
                 "account": "https://khala.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -1107,6 +1155,10 @@
                 "extrinsic": "https://spiritnet.subscan.io/extrinsic/{hash}",
                 "account": "https://spiritnet.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -1159,6 +1211,10 @@
                 "extrinsic": "https://calamari.subscan.io/extrinsic/{hash}",
                 "account": "https://calamari.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -1211,6 +1267,10 @@
                 "extrinsic": "https://quartz.subscan.io/extrinsic/{hash}",
                 "account": "https://quartz.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "externalApi": {
@@ -1357,6 +1417,10 @@
                 "extrinsic": "https://acala.subscan.io/extrinsic/{hash}",
                 "account": "https://acala.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -1401,6 +1465,10 @@
                 "extrinsic": "https://astar.subscan.io/extrinsic/{hash}",
                 "account": "https://astar.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -1444,6 +1512,10 @@
                 "extrinsic": "https://parallel.subscan.io/extrinsic/{hash}",
                 "account": "https://parallel.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -1531,6 +1603,14 @@
                 "name": "Patract node"
             }
         ],
+        "explorers": [
+            {
+                "name": "Statescan",
+                "account": "https://statemint.statescan.io/account/{address}",
+                "extrinsic": "https://statemint.statescan.io/extrinsic/{hash}",
+                "event": null
+            }
+        ],
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/statemine.json",
             "overridesCommon": true
@@ -1565,6 +1645,12 @@
                 "name": "OnFinality node"
             }
         ],
+        "explorers": [
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
+            }
+        ],
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/types/subsocial.json",
             "overridesCommon": false
@@ -1597,6 +1683,10 @@
                 "extrinsic": "https://robonomics.subscan.io/extrinsic/{hash}",
                 "account": "https://robonomics.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -1692,6 +1782,12 @@
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/kintsugi.json",
             "overridesCommon": true
         },
+        "explorers": [
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
+            }
+        ],
         "color": "linear-gradient(315deg, #180C2B 0%, #1E3258 100%)",
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Kintsugi.svg",
         "addressPrefix": 2092
@@ -1836,6 +1932,10 @@
                 "extrinsic": "https://crab.subscan.io/extrinsic/{hash}",
                 "account": "https://crab.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -1862,6 +1962,12 @@
             {
                 "url": "wss://para.subsocial.network",
                 "name": "Dappforce node"
+            }
+        ],
+        "explorers": [
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -1991,6 +2097,10 @@
                 "extrinsic": "https://centrifuge-parachain.subscan.io/extrinsic/{hash}",
                 "account": "https://centrifuge-parachain.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -2049,6 +2159,12 @@
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/hydra_dx.json",
             "overridesCommon": true
         },
+        "explorers": [
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
+            }
+        ],
         "color": "linear-gradient(315.17deg, #081152 19.76%, #F569AD 100%)",
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/HydraDX.svg",
         "addressPrefix": 63

--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -925,12 +925,6 @@
                 "name": "Hydradx node"
             }
         ],
-        "explorers": [
-            {
-                "name": "Sub.ID",
-                "account": "https://sub.id/{address}"
-            }
-        ],
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/basilisk.json",
             "overridesCommon": true
@@ -1778,12 +1772,6 @@
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/kintsugi.json",
             "overridesCommon": true
         },
-        "explorers": [
-            {
-                "name": "Sub.ID",
-                "account": "https://sub.id/{address}"
-            }
-        ],
         "color": "linear-gradient(315deg, #180C2B 0%, #1E3258 100%)",
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Kintsugi.svg",
         "addressPrefix": 2092

--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -925,6 +925,12 @@
                 "name": "Hydradx node"
             }
         ],
+        "explorers": [
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
+            }
+        ],
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/basilisk.json",
             "overridesCommon": true

--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -1762,6 +1762,14 @@
                 "name": "Kintsugi Labs"
             }
         ],
+        "explorers": [
+            {
+                "name": "Subscan",
+                "extrinsic": "https://kintsugi.subscan.io/extrinsic/{hash}",
+                "account": "https://kintsugi.subscan.io/account/{address}",
+                "event": null
+            }
+        ],
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/kintsugi.json",
             "overridesCommon": true
@@ -1876,6 +1884,14 @@
             {
                 "url": "wss://rpc.litmus-parachain.litentry.io",
                 "name": "Litenry node"
+            }
+        ],
+        "explorers": [
+            {
+                "name": "Subscan",
+                "extrinsic": "https://litmus.subscan.io/extrinsic/{hash}",
+                "account": "https://litmus.subscan.io/account/{address}",
+                "event": null
             }
         ],
         "types": {

--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -2139,12 +2139,6 @@
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/hydra_dx.json",
             "overridesCommon": true
         },
-        "explorers": [
-            {
-                "name": "Sub.ID",
-                "account": "https://sub.id/{address}"
-            }
-        ],
         "color": "linear-gradient(315.17deg, #081152 19.76%, #F569AD 100%)",
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/HydraDX.svg",
         "addressPrefix": 63

--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -559,10 +559,6 @@
                 "extrinsic": "https://karura.subscan.io/extrinsic/{hash}",
                 "account": "https://karura.subscan.io/account/{address}",
                 "event": null
-            },
-            {
-                "name": "Sub.ID",
-                "account": "https://sub.id/{address}"
             }
         ],
         "externalApi": {

--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -559,6 +559,10 @@
                 "extrinsic": "https://karura.subscan.io/extrinsic/{hash}",
                 "account": "https://karura.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "externalApi": {
@@ -749,10 +753,6 @@
                 "extrinsic": "https://shiden.subscan.io/extrinsic/{hash}",
                 "account": "https://shiden.subscan.io/account/{address}",
                 "event": null
-            },
-            {
-                "name": "Sub.ID",
-                "account": "https://sub.id/{address}"
             }
         ],
         "externalApi": {

--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -1589,14 +1589,6 @@
                 "name": "Patract node"
             }
         ],
-        "explorers": [
-            {
-                "name": "Statescan",
-                "account": "https://statemint.statescan.io/account/{address}",
-                "extrinsic": "https://statemint.statescan.io/extrinsic/{hash}",
-                "event": null
-            }
-        ],
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/statemine.json",
             "overridesCommon": true
@@ -2043,6 +2035,10 @@
                 "extrinsic": "https://integritee.subscan.io/extrinsic/{hash}",
                 "account": "https://integritee.subscan.io/account/{address}",
                 "event": null
+            },
+            {
+                "name": "Sub.ID",
+                "account": "https://sub.id/{address}"
             }
         ],
         "types": {

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -1072,10 +1072,6 @@
                 "extrinsic": "https://kintsugi.subscan.io/extrinsic/{hash}",
                 "account": "https://kintsugi.subscan.io/account/{address}",
                 "event": null
-            },
-            {
-                "name": "Sub.ID",
-                "account": "https://sub.id/{address}"
             }
         ],
         "types": {
@@ -2137,6 +2133,14 @@
             {
                 "url": "wss://rpc.litmus-parachain.litentry.io",
                 "name": "Litenry node"
+            }
+        ],
+        "explorers": [
+            {
+                "name": "Subscan",
+                "extrinsic": "https://litmus.subscan.io/extrinsic/{hash}",
+                "account": "https://litmus.subscan.io/account/{address}",
+                "event": null
             }
         ],
         "types": {


### PR DESCRIPTION
Added Sub ID for next Networks:

1. Polkadot 
2. Kusama
3. Acala
4. Astar
5. Khala
6. Karura 
7. Bifrost
8. Statemine
9. Kilt Spiritnet
10. Altair
11. Basilisk
12. Quartz
13. Calamari
14. Subsocial Solochain
15. Subsocial Parachain
16. Robonomoics
17. Integritee Network
18. Centrifuge
19. Edgware
20. Crab

Added Statescan for Statemine, Statemint does not have accounts with balances yet

Added Subscan for Kintsugi and Litmus