### PR TITLE
Adding aUSD and change kUSD

### DIFF
--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -1265,7 +1265,7 @@
                 "type": "statemine",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KUSD.svg",
                 "typeExtras": {
-                    "assetId": "5003"
+                    "assetId": "106"
                 }
             },
             {

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -1265,7 +1265,7 @@
                 "type": "statemine",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KUSD.svg",
                 "typeExtras": {
-                    "assetId": "999"
+                    "assetId": "5003"
                 }
             },
             {

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -434,13 +434,12 @@
                 "symbol": "kUSD",
                 "precision": 12,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KUSD.svg",
-                "priceId": "tether",
                 "type": "orml",
                 "typeExtras": {
-                    "currencyIdScale": "0x0081",
+                    "currencyIdScale": "0x9999",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
                     "existentialDeposit": "10000000000",
-                    "transfersEnabled": true
+                    "transfersEnabled": false
                 }
             },
             {
@@ -617,6 +616,20 @@
                     "currencyIdScale": "0x050300",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
                     "existentialDeposit": "1000000000000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 15,
+                "symbol": "aUSD",
+                "precision": 12,
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/AUSD.svg",
+                "priceId": "tether",
+                "type": "orml",
+                "typeExtras": {
+                    "currencyIdScale": "0x0081",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "10000000000",
                     "transfersEnabled": true
                 }
             }
@@ -978,14 +991,13 @@
                 "assetId": 5,
                 "symbol": "kUSD",
                 "precision": 12,
-                "priceId": "tether",
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KUSD.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x0302",
+                    "currencyIdScale": "0x9999",
                     "currencyIdType": "node_primitives.currency.CurrencyId",
                     "existentialDeposit": "100000000",
-                    "transfersEnabled": true
+                    "transfersEnabled": false
                 }
             },
             {
@@ -996,6 +1008,20 @@
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x0404",
+                    "currencyIdType": "node_primitives.currency.CurrencyId",
+                    "existentialDeposit": "100000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 7,
+                "symbol": "aUSD",
+                "precision": 12,
+                "priceId": "tether",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/AUSD.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0302",
                     "currencyIdType": "node_primitives.currency.CurrencyId",
                     "existentialDeposit": "100000000",
                     "transfersEnabled": true
@@ -1239,7 +1265,7 @@
                 "type": "statemine",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KUSD.svg",
                 "typeExtras": {
-                    "assetId": "103"
+                    "assetId": "999"
                 }
             },
             {
@@ -1271,6 +1297,16 @@
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Karura.svg",
                 "typeExtras": {
                     "assetId": "107"
+                }
+            },
+            {
+                "assetId": 6,
+                "symbol": "aUSD",
+                "precision": 12,
+                "type": "statemine",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/AUSD.svg",
+                "typeExtras": {
+                    "assetId": "103"
                 }
             }
         ],

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -1265,7 +1265,7 @@
                 "type": "statemine",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KUSD.svg",
                 "typeExtras": {
-                    "assetId": "106"
+                    "assetId": "100210028"
                 }
             },
             {
@@ -1304,6 +1304,7 @@
                 "symbol": "aUSD",
                 "precision": 12,
                 "type": "statemine",
+                "priceId": "tether",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/AUSD.svg",
                 "typeExtras": {
                     "assetId": "103"

--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -436,7 +436,7 @@
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KUSD.svg",
                 "type": "orml",
                 "typeExtras": {
-                    "currencyIdScale": "0x9999",
+                    "currencyIdScale": "0x050f27",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
                     "existentialDeposit": "10000000000",
                     "transfersEnabled": false
@@ -994,7 +994,7 @@
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KUSD.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x9999",
+                    "currencyIdScale": "0x070f270000",
                     "currencyIdType": "node_primitives.currency.CurrencyId",
                     "existentialDeposit": "100000000",
                     "transfersEnabled": false


### PR DESCRIPTION
 This PR replaces kUSD to aUSD in Parallel Heiko, Bifrost and Karura
---
On Parallel Heiko was used a cheat, kUSD id was changed on CKSM as supply for it = 0:

<details>
  <summary>cheat!</summary>

<img width="1512" alt="Screenshot 2022-04-12 at 14 24 00" src="https://user-images.githubusercontent.com/40560660/162949697-d90311c9-1f7d-4e72-8e56-70eb1df43862.png">

</details>

