### PR TITLE
Changing a test account for Astar network

### DIFF
--- a/tests/chains_for_testBalance.json
+++ b/tests/chains_for_testBalance.json
@@ -82,7 +82,7 @@
     {
         "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
         "name": "Astar",
-        "account": "0xe470631233212bfb8e10b6d56203d8f7580f5022a8f8207a1bb21c404dc68e6b"
+        "account": "0x9ddc0006c5f85d684175924636077cb21381274738bcf0f74f86384425da51b0"
     },
     {
         "chainId": "f22b7850cdd5a7657bbfd90ac86441275bbc57ace3d2698a740c7b0ec4de5ec3",


### PR DESCRIPTION
Previous account for Astar network haven't balance:
https://astar.subscan.io/account/b6pba6jZYphJro4v7xf8H93K8Xei4WtwtL2hAtawJcJnpAZ
was replaced by:
https://astar.subscan.io/account/ZWHAWhnDvz5sMoYkfYSBsuvRk4ye4QbuVeW3sziVaphV4BX