### PR TITLE
chore: change kodadot url

### DIFF
--- a/dapps/README.md
+++ b/dapps/README.md
@@ -14,7 +14,7 @@
 | Interlay Rewards Claim            | https://crowdloan.interlay.io/                   | crowdloans              |
 | Kanaria                           | https://kanaria.rmrk.app/                        | nft                     |
 | Kintsugi Hub                      | https://kintsugi.interlay.io/                    | staking,defi,crowdloans |
-| KodaDot                           | https://kodadot.xyz/rmrk/gallery                 | nft                     |
+| KodaDot                           | https://kodadot.xyz/                             | nft                     |
 | Moonbeam                          | https://apps.moonbeam.network/moonbeam           | staking,crowdloans,evm  |
 | Moonriver                         | https://apps.moonbeam.network/moonriver          | staking,crowdloans,evm  |
 | MyTrade                           | https://mytrade.org/                             | defi,evm                |

--- a/dapps/dapps.json
+++ b/dapps/dapps.json
@@ -100,7 +100,7 @@
     {
       "name": "KodaDot",
       "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/dapps/color/KodaDot.png",
-      "url": "https://kodadot.xyz/rmrk/gallery",
+      "url": "https://kodadot.xyz/",
       "categories": [
         "nft"
       ]

--- a/dapps/dapps_dev.json
+++ b/dapps/dapps_dev.json
@@ -104,7 +104,7 @@
     {
       "name": "KodaDot",
       "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/dapps/color/KodaDot.png",
-      "url": "https://kodadot.xyz/rmrk/gallery",
+      "url": "https://kodadot.xyz/",
       "categories": [
         "nft"
       ]


### PR DESCRIPTION
We would like to change the kodadot URL to domain because the current url path is invalid.

![image](https://user-images.githubusercontent.com/31397967/167254409-ea391bcf-d44f-40c8-831f-82e45eac91b1.png)


ref [#2968](https://github.com/kodadot/nft-gallery/issues/2968#issue-1228586929)