### PR TITLE
Fixing crowdloan paraid

### DIFF
--- a/crowdloan/kusama.json
+++ b/crowdloan/kusama.json
@@ -375,5 +375,24 @@
     "description": "The Bajun Network is Canary Network for Ajuna and will host games. It will be mainly used for testing and introducing new Ajuna features, services and functionalities",
     "website": "https://ajuna.io",
     "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Bajun.svg"
+  },
+  {
+    "paraid": "2003",
+    "name": "Karura",
+    "token": "KAR",
+    "description": "All-in-one DeFi hub of Kusama",
+    "website": "https://acala.network/karura",
+    "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Karura.svg",
+    "rewardRate": 12,
+    "customFlow": "Karura"
+  },
+  {
+    "paraid": "2112",
+    "name": "Moonriver",
+    "token": "MOVR",
+    "description": "Please use Moonriver DApp for contribution",
+    "website": "https://moonbeam.network/networks/moonriver/",
+    "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Moonriver.svg",
+    "rewardRate": 4.5
   }
 ]


### PR DESCRIPTION
Crowdloan Id was changed for Karura and Moonriver on Kusama network, as a result it was broken for our app:

<details>
  <summary>Problem</summary>

<img width="480" alt="Screenshot 2022-05-11 at 17 34 26" src="https://user-images.githubusercontent.com/40560660/167875467-f0738648-d672-4baf-ab1e-2f3c4333c6ea.jpeg">

</details>


As resolve I have changed paraid:
<details>
  <summary>Karura proof</summary>

<img width="958" alt="Screenshot 2022-05-11 at 17 34 26" src="https://user-images.githubusercontent.com/40560660/167875647-e2ad760c-1837-4c2b-90dd-70248bf3f241.png">

Gq2No2gcF6s4DLfzzuB53G5opWCoCtK9tZeVGRGcmkSDGoK

https://kusama.subscan.io/parachain/2000

<img width="1376" alt="Screenshot 2022-05-11 at 17 34 55" src="https://user-images.githubusercontent.com/40560660/167875749-6cc2ce24-f7d0-49b0-9cf3-157708c0dc13.png">

</details>

<details>
  <summary>Moonriver proof</summary>

<img width="1141" alt="Screenshot 2022-05-11 at 17 37 39" src="https://user-images.githubusercontent.com/40560660/167876306-7267461a-dbb2-4b77-b1c6-4871a9b80a1b.png">

FFuCbRwsDTkj1cc2w6dvBmXvumyoZR6QgfAv1LwL3kBgmbX

https://kusama.subscan.io/parachain/2023

<img width="1366" alt="Screenshot 2022-05-11 at 17 38 11" src="https://user-images.githubusercontent.com/40560660/167876411-24b65432-0fe4-4464-8463-9493ab331b7a.png">


</details>