### PR TITLE
Changing subquery urls to new gapi projects

### DIFF
--- a/chains/v3/chains_dev.json
+++ b/chains/v3/chains_dev.json
@@ -60,11 +60,11 @@
         "externalApi": {
             "staking": {
                 "type": "subquery",
-                "url": "https://nova-polkadot.gapi.subquery.network"
+                "url": "https://nova-wallet-polkadot.gapi.subquery.network"
             },
             "history": {
                 "type": "subquery",
-                "url": "https://nova-polkadot.gapi.subquery.network"
+                "url": "https://nova-wallet-polkadot.gapi.subquery.network"
             },
             "crowdloans": {
                 "type": "github",
@@ -139,11 +139,11 @@
         "externalApi": {
             "staking": {
                 "type": "subquery",
-                "url": "https://nova-kusama.gapi.subquery.network"
+                "url": "https://nova-wallet-kusama.gapi.subquery.network"
             },
             "history": {
                 "type": "subquery",
-                "url": "https://nova-kusama.gapi.subquery.network"
+                "url": "https://nova-wallet-kusama.gapi.subquery.network"
             },
             "crowdloans": {
                 "type": "github",
@@ -201,11 +201,11 @@
         "externalApi": {
             "staking": {
                 "type": "subquery",
-                "url": "https://nova-westend.gapi.subquery.network"
+                "url": "https://nova-wallet-westend.gapi.subquery.network"
             },
             "history": {
                 "type": "subquery",
-                "url": "https://nova-westend.gapi.subquery.network"
+                "url": "https://nova-wallet-westend.gapi.subquery.network"
             },
             "crowdloans": {
                 "type": "github",


### PR DESCRIPTION
This PR is changing Polkadot/Kusama/Westend Subquery project from old to new one:

Polkadot:
old - https://project.subquery.network/project/nova-wallet/nova-polkadot
new - https://project.subquery.network/project/nova-wallet/nova-wallet-polkadot

Kusama:
old - https://project.subquery.network/project/nova-wallet/nova-kusama
new - https://project.subquery.network/project/nova-wallet/nova-wallet-kusama

Westend:
old - https://project.subquery.network/project/nova-wallet/nova-westend
new - https://project.subquery.network/project/nova-wallet/nova-wallet-westend