### PR TITLE
Fixing account list for balance testing

### DIFF
--- a/.github/workflows/update_network_list.yaml
+++ b/.github/workflows/update_network_list.yaml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       v3chains: ${{ steps.v3chains.outputs.any_changed }}
       dapps: ${{ steps.dapps.outputs.any_changed }}
-      v3chains_dev: ${{ steps.changed-files.outputs.any_changed }}
+      v3chains_dev: ${{ steps.v3chains_dev.outputs.any_changed }}
     steps:
       - name: Checkout current repository to Master branch
         uses: actions/checkout@v1

--- a/tests/chains_for_testBalance.json
+++ b/tests/chains_for_testBalance.json
@@ -145,11 +145,6 @@
         "account": "0xfcacdc1b0849908f55623b4249ab6c63823122703c6fa9e223e15c0b0fffd371"
     },
     {
-        "chainId": "a3d114c2b8d0627c1aa9b134eafcf7d05ca561fdc19fb388bb9457f81809fb23",
-        "name": "Nodle Solochain",
-        "account": "0xf233477e8d4e36baafb87987c74ae24e36cf33eb54485998e012e17acc421808"
-    },
-    {
         "chainId": "67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9",
         "name": "Westmint",
         "account": "0x340a806419d5e278172e45cb0e50da1b031795366c99ddfe0a680bd53b142c63"


### PR DESCRIPTION
That PR is fixing the problem in auto updating the list of test networks and accounts for the [balance test](https://github.com/nova-wallet/nova-wallet-android/blob/develop/app/src/androidTest/java/io/novafoundation/nova/balances/BalancesIntegrationTest.kt#L45).
