### PR TITLE
Fixing some genesis for chains_dev

### DIFF
--- a/chains/v3/chains_dev.json
+++ b/chains/v3/chains_dev.json
@@ -1431,7 +1431,7 @@
         "addressPrefix": 28
     },
     {
-        "chainId": "9d3ea49f13d993d093f209c42f97a6b723b84d3b9aa8461be9bb19ee13e7b4fd",
+        "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
         "name": "Parallel Heiko",
         "assets": [
@@ -1610,7 +1610,7 @@
         "addressPrefix": 10041
     },
     {
-        "chainId": "4d812836a05a7ea37767325acadff956ce472474dd44dd2e7f15d16fbfc68cdb",
+        "chainId": "aa3876c1dc8a1afcc2e9a685a49ff7704cfd36ad8c90bf2702b9d1b00cc40011",
         "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
         "name": "Altair",
         "assets": [
@@ -1763,7 +1763,7 @@
         "addressPrefix": 38
     },
     {
-        "chainId": "f25c85c4ffc4863b599a443e5301f7f4120c9a21042d35942b9e844346060db1",
+        "chainId": "a0c6e3bac382b316a68bca7141af1fba507207594c761076847ce358aeedcc21",
         "name": "KILT Peregrine",
         "assets": [
             {


### PR DESCRIPTION
As the result of [test](https://github.com/nova-wallet/nova-utils/runs/6668855052?check_suite_focus=true) chains_dev, was found some wrong genesises:

- [Parallel Heiko](https://github.com/nova-wallet/nova-utils/pull/421/files#diff-d3439c28b8c562ca12cf270175b475b4cb958375112b5c263374399309ee30a1R1434)

<details>
  <summary>Spoiler!</summary>

<img width="1624" alt="Screenshot 2022-05-31 at 14 20 31" src="https://user-images.githubusercontent.com/40560660/171161909-c5c07c69-6dc7-4bfc-a40c-c91da424210a.png">

</details>

- [Altair](https://github.com/nova-wallet/nova-utils/pull/421/files#diff-d3439c28b8c562ca12cf270175b475b4cb958375112b5c263374399309ee30a1R1613)

<details>
  <summary>Spoiler!</summary>

<img width="1624" alt="Screenshot 2022-05-31 at 14 21 20" src="https://user-images.githubusercontent.com/40560660/171162041-88f9e36b-0269-4d0c-9c57-d26a5bc6438d.png">

</details>

-  [KILT Peregrine](https://github.com/nova-wallet/nova-utils/pull/421/files#diff-d3439c28b8c562ca12cf270175b475b4cb958375112b5c263374399309ee30a1R1766)

<details>
  <summary>Spoiler!</summary>

<img width="1624" alt="Screenshot 2022-05-31 at 14 22 32" src="https://user-images.githubusercontent.com/40560660/171162218-8349d3f8-6473-4d42-aa06-e7923683b717.png">


</details>