### PR TITLE
Promote subquery urls to prod

### DIFF
--- a/chains/v4/chains.json
+++ b/chains/v4/chains.json
@@ -3253,11 +3253,11 @@
         "externalApi": {
             "staking": {
                 "type": "subquery",
-                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-polkadex__bm92Y"
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-polkadex"
             },
             "history": {
                 "type": "subquery",
-                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-polkadex__bm92Y"
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-polkadex"
             }
         },
         "color": "linear-gradient(315deg, #2B2D36 23.96%, #606169 100%)",

--- a/chains/v4/chains.json
+++ b/chains/v4/chains.json
@@ -3285,6 +3285,12 @@
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/origintrail.json",
             "overridesCommon": true
         },
+        "externalApi": {
+            "history": {
+                "type": "subquery",
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-origin-trail"
+            }
+        },
         "color": "linear-gradient(315deg, #B62EB1 0%, #E96CE5 100%)",
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/OriginTrail.svg",
         "addressPrefix": 101
@@ -3311,6 +3317,12 @@
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/bifrost_polkadot.json",
             "overridesCommon": true
         },
+        "externalApi": {
+            "history": {
+                "type": "subquery",
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bifrost-polkadot"
+            }
+        },
         "color": "linear-gradient(135deg, #D43079 26.21%, #2EA9E7 26.42%, #4584F5 40.32%, #AC57C0 60.21%, #E65659 80.19%, #FFBF12 100%)",
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Bifrost.svg",
         "addressPrefix": 6
@@ -3336,6 +3348,12 @@
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/litentry.json",
             "overridesCommon": true
+        },
+        "externalApi": {
+            "history": {
+                "type": "subquery",
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-litentry"
+            }
         },
         "color": "linear-gradient(315deg, #0E7227 0%, #5CC774 100%)",
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Litentry.svg",
@@ -3370,6 +3388,12 @@
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/unique.json",
             "overridesCommon": true
         },
+        "externalApi": {
+            "history": {
+                "type": "subquery",
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-unique"
+            }
+        },
         "color": "linear-gradient(315deg, #267DEE 0%, #5FC2F9 100%)",
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Unique.svg",
         "addressPrefix": 7391
@@ -3395,6 +3419,12 @@
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/dorafactory.json",
             "overridesCommon": true
+        },
+        "externalApi": {
+            "history": {
+                "type": "subquery",
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-dora"
+            }
         },
         "color": "linear-gradient(315deg, #E04E02 0%, #FCB350 100%)",
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/DoraFactory.svg",

--- a/chains/v4/chains_dev.json
+++ b/chains/v4/chains_dev.json
@@ -3561,7 +3561,7 @@
         "externalApi": {
             "history": {
                 "type": "subquery",
-                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-origin-trail__bm92Y"
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-origin-trail"
             }
         },
         "color": "linear-gradient(315deg, #B62EB1 0%, #E96CE5 100%)",
@@ -3593,7 +3593,7 @@
         "externalApi": {
             "history": {
                 "type": "subquery",
-                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bifrost-polkadot__bm92Y"
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-bifrost-polkadot"
             }
         },
         "color": "linear-gradient(135deg, #D43079 26.21%, #2EA9E7 26.42%, #4584F5 40.32%, #AC57C0 60.21%, #E65659 80.19%, #FFBF12 100%)",
@@ -3625,7 +3625,7 @@
         "externalApi": {
             "history": {
                 "type": "subquery",
-                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-litentry__bm92Y"
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-litentry"
             }
         },
         "color": "linear-gradient(315deg, #0E7227 0%, #5CC774 100%)",
@@ -3664,7 +3664,7 @@
         "externalApi": {
             "history": {
                 "type": "subquery",
-                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-unique__bm92Y"
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-unique"
             }
         },
         "color": "linear-gradient(315deg, #267DEE 0%, #5FC2F9 100%)",
@@ -3696,7 +3696,7 @@
         "externalApi": {
             "history": {
                 "type": "subquery",
-                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-dora__bm92Y"
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-dora"
             }
         },
         "color": "linear-gradient(315deg, #E04E02 0%, #FCB350 100%)",


### PR DESCRIPTION
This PR is:
- adding new networks to production
- changing subquery url to production as it was removed
- Fix polkadex url for prod

List of subquery project:
- [Polkadex](https://project.subquery.network/project/nova-wallet/nova-wallet-polkadex)
- [OriginTrail](https://project.subquery.network/project/nova-wallet/nova-wallet-origin-trail)
- [Bifrost Polkadot](https://project.subquery.network/project/nova-wallet/nova-wallet-bifrost-polkadot)
- [Litentry](https://project.subquery.network/project/nova-wallet/nova-wallet-litentry)
- [UNIQUE](https://project.subquery.network/project/nova-wallet/nova-wallet-unique)
- [Dora](https://project.subquery.network/project/nova-wallet/nova-wallet-dora)