### PR TITLE
Fix kar fee in Moonriver -> Karura transfer

### DIFF
--- a/xcm/transfers_dev.json
+++ b/xcm/transfers_dev.json
@@ -62,8 +62,7 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "proportional",
-                    "value": "12350000000000"
+                    "type": "standard"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
Transfering KAR from Moonriver to Karura will result in Karura taking fees for KAR, which is native  in it -> standard mode is used