### PR TITLE
Fix/kar fee

### DIFF
--- a/xcm/transfers_dev.json
+++ b/xcm/transfers_dev.json
@@ -62,8 +62,7 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "proportional",
-                    "value": "12350000000000"
+                    "type": "standard"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/transfers_dev.json
+++ b/xcm/transfers_dev.json
@@ -62,7 +62,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "8000000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
```
ExtrinsicBaseWeight -> systemBlockWeights().perClass.normal.baseExtrinsic (125_000_000)
WEIGHT_PER_SECOND -> 1_000_000_000_000 (10^12)

base_tx_per_second = 1_000_000_000_000 / 125_000_000 = 8000

base_tx_in_kar = cent(KAR) / 10
base_tx_in_kar = 0.001 * 10^12 (Kar precision) = 1000000000

kar_per_second = base_tx_per_second * base_tx_in_kar = 8000 * 1000000000 = 8000000000000
```

https://github.com/AcalaNetwork/Acala/blob/fb31aac0b2a69db5cd0ec6f0ba39f3427455a202/runtime/karura/src/constants.rs#L83