### PR TITLE
Update bnc reserves rate

### DIFF
--- a/xcm/transfers_dev.json
+++ b/xcm/transfers_dev.json
@@ -23,7 +23,14 @@
       "multiLocation": {
         "parachainId": 2001,
         "generalKey": "0x0001"
-      }
+      },
+     "reserveFee": {
+       "mode": {
+         "type": "proportional",
+         "value": "6400000000000"
+       },
+       "instructions": "xtokensReserve"
+     }
     }
   },
   "instructions": {
@@ -159,6 +166,7 @@
         {
           "assetId": 4,
           "assetLocation": "BNC",
+          "hasReserveFee": true,
           "assetLocationPath": {
             "type": "concrete",
             "path": {
@@ -183,13 +191,6 @@
               "type": "xtokens"
             }
           ],
-          "reserveFee": {
-            "mode": {
-              "type": "proportional",
-              "value": "1"
-            },
-            "instructions": "xtokensReserve"
-          }
         }
       ]
     }

--- a/xcm/transfers_dev.json
+++ b/xcm/transfers_dev.json
@@ -166,7 +166,6 @@
         {
           "assetId": 4,
           "assetLocation": "BNC",
-          "hasReserveFee": true,
           "assetLocationPath": {
             "type": "concrete",
             "path": {
@@ -190,7 +189,7 @@
               },
               "type": "xtokens"
             }
-          ],
+          ]
         }
       ]
     }


### PR DESCRIPTION
Also moved reserves fee info to asset locations so it can be reused. Added "hasReserveFee" flag to indicate

```
WEIGHT_PER_SECOND = 1_000_000_000_000 (10^12)

base_weight = systemBlockWeights().perClass.normal.baseExtrinsic (125_000_000)
base_tx_per_second = WEIGHT_PER_SECOND / base_weight = 1_000_000_000_000 / 125_000_000 = 8000

xcm_base_tx_fee = cent(BNC) / 10 = 0.001 * 10^12 (BNC precision) = 1000000000

fee_per_second = base_tx_per_second * xcm_base_tx_fee = 8000 * 1000000000 = 8000000000000

ksm_per_second = fee_per_second / 100 = 8000000000000 / 100 = 80000000000

BncPerSecond = ksm_per_second * 80 = 80000000000 * 80 = 6400000000000
```

https://github.com/bifrost-finance/bifrost/blob/b9c7aa79f760a63ba281b3e8f2c825ed65f27b8e/runtime/bifrost-kusama/src/lib.rs#L1107
https://github.com/bifrost-finance/bifrost/blob/d7bc68509d4b59d7a794f6267f9f135fafded320/runtime/bifrost-kusama/src/constants.rs#L61