### PR TITLE
Fix for acala_mandala network

### DIFF
--- a/chains/v4/chains_dev.json
+++ b/chains/v4/chains_dev.json
@@ -2163,16 +2163,16 @@
         ],
         "nodes": [
             {
-                "url": "wss://rpc.pinknode.io/mandala/explorer",
-                "name": "Pinknode node"
-            },
-            {
                 "url": "wss://acala-mandala.api.onfinality.io/public-ws",
                 "name": "OnFinality node"
             },
             {
                 "url": "wss://mandala.polkawallet.io",
                 "name": "Polkawallet"
+            },
+            {
+                "url": "wss://rpc.pinknode.io/mandala/explorer",
+                "name": "Pinknode node"
             }
         ],
         "options": [


### PR DESCRIPTION
That PR changing order for Acala Mandala nodes, as Pinknode isn't available:

<details>
  <summary>Proof</summary>

<img width="1624" alt="Screenshot 2022-06-22 at 19 25 24" src="https://user-images.githubusercontent.com/40560660/175085290-0face23f-5ea7-4882-b9c0-79da4cfa83ef.png">
</details>

