### PR TITLE
Bifrost, Karura, Acala fee coefficients

### DIFF
--- a/xcm/transfers_dev.json
+++ b/xcm/transfers_dev.json
@@ -116,8 +116,7 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "proportional",
-                    "value": "8000000000000"
+                    "type": "standard"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -176,7 +175,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "1"
+                    "value": "309393033444720000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -342,8 +341,7 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "proportional",
-                    "value": "1"
+                    "type": "standard"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
```
BNC precision = 12

fn xcm_base_tx_fee() -> Balance {
	cent(CurrencyId::Native(TokenSymbol::BNC)) / 10 // 0.1 BNC
}

pub const WEIGHT_PER_SECOND: Weight = 1_000_000_000_000;
pub const WEIGHT_PER_MILLIS: Weight = WEIGHT_PER_SECOND / 1000; // 1_000_000_000
pub const WEIGHT_PER_MICROS: Weight = WEIGHT_PER_MILLIS / 1000; // 1_000_000
pub const WEIGHT_PER_NANOS: Weight = WEIGHT_PER_MICROS / 1000; // 1_000
pub const ExtrinsicBaseWeight: Weight = 86_298 * WEIGHT_PER_NANOS;

pub fn ksm_per_second() -> u128 {
	// WEIGHT_PER_NANOS = WEIGHT_PER_MICROS / 1000 = WEIGHT_PER_MILLIS / 1_000_000 = WEIGHT_PER_SECOND / 1_000_000_000
	// base_weight = 86_298 * WEIGHT_PER_SECOND / 1_000_000_000
	let base_weight = Balance::from(ExtrinsicBaseWeight::get());

	// base_tx_per_second = WEIGHT_PER_SECOND / (86_298 * WEIGHT_PER_SECOND / 1_000_000_000) = 1_000_000_000 / 86_298
	let base_tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;

	// xcm_base_tx_fee = 0.1 BNC = 100_000_000_000
	// fee_per_second = 100_000_000_000 * 1_000_000_000 / 86_298
	let fee_per_second = base_tx_per_second * xcm_base_tx_fee();

	// 1_000_000_000_000_000_000 / 86_298 / 100 = 115877540616
	fee_per_second / 100
}

movr_per_second = ksm_per_second() * 267 * 10_000 = 115877540616 * 267 * 10_000 = 309_393_033_444_720_000
```