### PR TITLE
Improve KAR/ACA fee calculation

### DIFF
--- a/xcm/transfers_dev.json
+++ b/xcm/transfers_dev.json
@@ -116,7 +116,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "11587754061508"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -364,7 +365,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "11587754061508"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
aca units per seconds ~ 11587754061508

```
pub fn base_tx_in_aca() -> Balance {
	cent(ACA) / 10 // 1_000_000_000
}

pub const WEIGHT_PER_SECOND: Weight = 1_000_000_000_000;
pub const WEIGHT_PER_MILLIS: Weight = WEIGHT_PER_SECOND / 1000; // 1_000_000_000
pub const WEIGHT_PER_MICROS: Weight = WEIGHT_PER_MILLIS / 1000; // 1_000_000
pub const WEIGHT_PER_NANOS: Weight = WEIGHT_PER_MICROS / 1000; // 1_000
pub const ExtrinsicBaseWeight: Weight = 86_298 * WEIGHT_PER_NANOS;

pub fn aca_per_second() -> u128 {
	// WEIGHT_PER_NANOS = WEIGHT_PER_MICROS / 1000 = WEIGHT_PER_MILLIS / 1_000_000 = WEIGHT_PER_SECOND / 1_000_000_000
	// base_weight = 86_298 * WEIGHT_PER_SECOND / 1_000_000_000
	let base_weight = Balance::from(ExtrinsicBaseWeight::get());

	// base_tx_per_second = WEIGHT_PER_SECOND / (86_298 * WEIGHT_PER_SECOND / 1_000_000_000) = 1_000_000_000 / 86_298
	let base_tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;

	// 1_000_000_000 * 1_000_000_000 / 86_298 = 1_000_000_000_000_000_000 / 86_298 ~ 11587754061508
	base_tx_per_second * base_tx_in_aca()
}
```

The same calculations for Karura