### PR TITLE
Fix ACA/KAR cross chain fees

### DIFF
--- a/xcm/transfers_dev.json
+++ b/xcm/transfers_dev.json
@@ -117,7 +117,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "11588000000000"
+                    "value": "23176000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -366,7 +366,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "11588000000000"
+                    "value": "23176000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
Multiplied by 2 calculated weight to receive ACA/KAR tokens on Acala and Kararu. This addresses cross chain fee underestimation problem until we discuss the problem with Acala team