### PR TITLE
Make a separate staking type for aura relay chain

### DIFF
--- a/chains/v4/chains_dev.json
+++ b/chains/v4/chains_dev.json
@@ -1402,7 +1402,7 @@
                 "symbol": "EDG",
                 "precision": 18,
                 "priceId": "edgeware",
-                "staking": "relaychain"
+                "staking": "aura-relaychain"
             }
         ],
         "nodes": [


### PR DESCRIPTION
For iOS currently it is not so easy and fast to check whether some pallet is present during staking initialisation. So, it is proposed to add a separate type for aura like relay chain staking