### PR TITLE
Teleport KSM from Kusama to Statemine

### DIFF
--- a/xcm/transfers_dev.json
+++ b/xcm/transfers_dev.json
@@ -85,6 +85,12 @@
       "ClearOrigin",
       "BuyExecution",
       "DepositAsset"
+    ],
+    "xcmPalletTeleportDest": [
+      "ReceiveTeleportedAsset",
+      "ClearOrigin",
+      "BuyExecution",
+      "DepositAsset"
     ]
   },
   "networkBaseWeight": {
@@ -233,6 +239,19 @@
                 }
               },
               "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "standard"
+                  },
+                  "instructions": "xcmPalletTeleportDest"
+                }
+              },
+              "type": "xcmpallet-teleport"
             }
           ]
         }


### PR DESCRIPTION
Instructions:
https://github.com/paritytech/polkadot/blob/ac3cc3683406d9e3223612024d9cbdec5de72aec/xcm/xcm-executor/src/lib.rs#L431
https://github.com/paritytech/polkadot/blob/d22eb62fe40e55e15eb91d375f48cc540d83a47e/xcm/pallet-xcm/src/lib.rs#L869

New one: `ReceiveTeleportedAsset`
New transfer ype: `xcmpallet-teleport` which should use `xcmPallet.limited_teleport_assets`