### PR TITLE
KSM from Statemine to Kusama

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -481,7 +481,7 @@
           "assetId": 0,
           "assetLocation": "KSM-Statemine",
           "assetLocationPath": {
-            "type": "relative"
+            "type": "absolute"
           },
           "xcmTransfers": [
             {
@@ -497,6 +497,19 @@
                 }
               },
               "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "standard"
+                  },
+                  "instructions": "xcmPalletTeleportDest"
+                }
+              },
+              "type": "xcmpallet-teleport"
             }
           ]
         },


### PR DESCRIPTION
Statemine uses KSM multilocation for Kusama reserve. So location should be `absolute`