### PR TITLE
Fix KINT fee

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -333,7 +333,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "9656462"
+                    "value": "309013333334"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
According to https://github.com/interlay/interbtc/blob/master/parachain/runtime/kintsugi/src/xcm_config.rs#L98

```
fn base_tx_in_ksm() -> Balance {
    KSM.one() / 50_000 // 20_000_000
}

pub const WEIGHT_PER_SECOND: Weight = 1_000_000_000_000;
pub const WEIGHT_PER_MILLIS: Weight = WEIGHT_PER_SECOND / 1000; // 1_000_000_000
pub const WEIGHT_PER_MICROS: Weight = WEIGHT_PER_MILLIS / 1000; // 1_000_000
pub const WEIGHT_PER_NANOS: Weight = WEIGHT_PER_MICROS / 1000; // 1_000
pub const ExtrinsicBaseWeight: Weight = 86_298 * WEIGHT_PER_NANOS;

pub fn ksm_per_second() -> u128 {
	// WEIGHT_PER_NANOS = WEIGHT_PER_MICROS / 1000 = WEIGHT_PER_MILLIS / 1_000_000 = WEIGHT_PER_SECOND / 1_000_000_000
	// base_weight = 86_298 * WEIGHT_PER_SECOND / 1_000_000_000
    let base_weight = Balance::from(ExtrinsicBaseWeight::get());

    // base_tx_per_second = WEIGHT_PER_SECOND / (86_298 * WEIGHT_PER_SECOND / 1_000_000_000) = 1_000_000_000 / 86_298 ~ 11588
    let base_tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;

    // 11588 * 20_000_000 = 231_760_000_000
    base_tx_per_second * base_tx_in_ksm()
}

// 231_760_000_000 * 4 / 3 ~ 309_013_333_334
kint_per_second = (ksm_per_second() * 4) / 3
```