### PR TITLE
Remove SubID for Interlay as not functional

### DIFF
--- a/chains/v4/chains_dev.json
+++ b/chains/v4/chains_dev.json
@@ -3214,10 +3214,6 @@
                 "extrinsic": "https://interlay.subscan.io/extrinsic/{hash}",
                 "account": "https://interlay.subscan.io/account/{address}",
                 "event": null
-            },
-            {
-                "name": "Sub.ID",
-                "account": "https://sub.id/{address}"
             }
         ],
         "types": {


### PR DESCRIPTION
Network is shown in balances SubID, but not showing INTR balance:
[Subscan](https://interlay.subscan.io/account/wdCG1vGJ82gT5n291kUjeEYy4uYDhSXD4tWhd6YhpTdtC9vF8)  vs [SubID](https://sub.id/wdCG1vGJ82gT5n291kUjeEYy4uYDhSXD4tWhd6YhpTdtC9vF8/balances) 