### PR TITLE
Fix fee for Karura, Acala, Kintsugi

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -136,7 +136,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "23176000000000"
+                    "value": "11655000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -204,7 +204,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "37078400000000"
+                    "value": "18648000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -325,7 +325,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "309013333334"
+                    "value": "310800000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -408,7 +408,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "23176000000000"
+                    "value": "11655000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
1) Fee in Karura

```
pub fn base_tx_in_kar() -> Balance {
	cent(KAR) / 10 // 1_000_000_000
}

pub const WEIGHT_PER_SECOND: Weight = 1_000_000_000_000;
pub const WEIGHT_PER_MILLIS: Weight = WEIGHT_PER_SECOND / 1000; // 1_000_000_000
pub const WEIGHT_PER_MICROS: Weight = WEIGHT_PER_MILLIS / 1000; // 1_000_000
pub const WEIGHT_PER_NANOS: Weight = WEIGHT_PER_MICROS / 1000; // 1_000
pub const ExtrinsicBaseWeight: Weight = 85_795 * WEIGHT_PER_NANOS;

pub fn kar_per_second() -> u128 {
	// WEIGHT_PER_NANOS = WEIGHT_PER_MICROS / 1000 = WEIGHT_PER_MILLIS / 1_000_000 = WEIGHT_PER_SECOND / 1_000_000_000
	// base_weight = 85_795 * WEIGHT_PER_SECOND / 1_000_000_000
	let base_weight = Balance::from(ExtrinsicBaseWeight::get());

	// base_tx_per_second = WEIGHT_PER_SECOND / (86_298 * WEIGHT_PER_SECOND / 1_000_000_000) = 1_000_000_000 / 85_795 ~ 11655
	let base_tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;

	// 1_000_000_000 * 11655 =  11655000000000
	base_tx_per_second * base_tx_in_kar()
}

pub fn ksm_per_second() -> u128 {
	// 11655000000000 / 50 = 233100000000
	kar_per_second() / 50
}

// 233100000000 * 80 = 18648000000000
bnc_per_second = ksm_per_second() * 80
```

2) Acala

```
pub fn base_tx_in_aca() -> Balance {
	cent(ACA) / 10 // 1_000_000_000
}

pub const WEIGHT_PER_SECOND: Weight = 1_000_000_000_000;
pub const WEIGHT_PER_MILLIS: Weight = WEIGHT_PER_SECOND / 1000; // 1_000_000_000
pub const WEIGHT_PER_MICROS: Weight = WEIGHT_PER_MILLIS / 1000; // 1_000_000
pub const WEIGHT_PER_NANOS: Weight = WEIGHT_PER_MICROS / 1000; // 1_000

https://github.com/paritytech/substrate/blob/polkadot-v0.9.23/frame/support/src/weights/extrinsic_weights.rs#L56
pub const ExtrinsicBaseWeight: Weight = 85_795 * WEIGHT_PER_NANOS;

pub fn aca_per_second() -> u128 {
	// WEIGHT_PER_NANOS = WEIGHT_PER_MICROS / 1000 = WEIGHT_PER_MILLIS / 1_000_000 = 
	// WEIGHT_PER_SECOND / 1_000_000_000 = 1_000_000_000_000 / 1_000_000_000 = 1_000
	// base_weight = 85_795 * 1_000 = 85_795_000
	let base_weight = Balance::from(ExtrinsicBaseWeight::get());

	// base_tx_per_second = WEIGHT_PER_SECOND / 85_795_000 = 1_000_000_000_000 / 85_795_000 = 1_000_000_000 / 85_795 = 11655
	let base_tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;

	// 11655 * 1_000_000_000 = 11_655_000_000_000
	base_tx_per_second * base_tx_in_aca()
}

pub fn dot_per_second() -> u128 {
	// 11_655_000_000_000 / (50 * 100) ~
	aca_per_second() / 50 * dollar(DOT) / dollar(ACA)
}
```

3) Kintsugi

```
fn base_tx_in_ksm() -> Balance {
    KSM.one() / 50_000 // 20_000_000
}

pub const WEIGHT_PER_SECOND: Weight = 1_000_000_000_000;
pub const WEIGHT_PER_MILLIS: Weight = WEIGHT_PER_SECOND / 1000; // 1_000_000_000
pub const WEIGHT_PER_MICROS: Weight = WEIGHT_PER_MILLIS / 1000; // 1_000_000
pub const WEIGHT_PER_NANOS: Weight = WEIGHT_PER_MICROS / 1000; // 1_000

https://github.com/paritytech/substrate/blob/polkadot-v0.9.24/frame/support/src/weights/extrinsic_weights.rs#L56
pub const ExtrinsicBaseWeight: Weight = 85_795 * WEIGHT_PER_NANOS;

pub fn ksm_per_second() -> u128 {
	// WEIGHT_PER_NANOS = WEIGHT_PER_MICROS / 1000 = WEIGHT_PER_MILLIS / 1_000_000 = WEIGHT_PER_SECOND / 1_000_000_000
	// base_weight = 85_795 * WEIGHT_PER_SECOND / 1_000_000_000
    let base_weight = Balance::from(ExtrinsicBaseWeight::get());

    // base_tx_per_second = WEIGHT_PER_SECOND / (85_795 * WEIGHT_PER_SECOND / 1_000_000_000) = 1_000_000_000 / 85_795 ~ 11655
    let base_tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;

    // 11655 * 20_000_000 = 233_100_000_000
    base_tx_per_second * base_tx_in_ksm()
}

// 231_760_000_000 * 4 / 3 ~ 310800000000
kint_per_second = (ksm_per_second() * 4) / 3
```