### PR TITLE
Changing Zeitgeist SubQuery url

### DIFF
--- a/chains/v4/chains_dev.json
+++ b/chains/v4/chains_dev.json
@@ -2722,7 +2722,11 @@
         "externalApi": {
             "history": {
                 "type": "subquery",
-                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-zeitgeist"
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-zeitgeist__bm92Y"
+            },
+            "staking": {
+                "type": "subquery",
+                "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-zeitgeist__bm92Y"
             }
         },
         "color": "linear-gradient(315deg, #132849 0%, #2C5AA6 100%)",


### PR DESCRIPTION
New Zeitgeist staging have just been sync:

https://project.subquery.network/project/nova-wallet/nova-wallet-zeitgeist

<img width="1284" alt="Screenshot 2022-07-07 at 10 06 06" src="https://user-images.githubusercontent.com/40560660/177712713-187f3296-fb06-4352-9f41-c69316a3ad24.png">

