### PR TITLE
Fix Monriver -> Karura BNC fee

### DIFF
--- a/xcm/v2/transfers.json
+++ b/xcm/v2/transfers.json
@@ -198,7 +198,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "18648000000000"
+                    "value": "27972000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -204,7 +204,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "18648000000000"
+                    "value": "27972000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
When not native token is sent to Karura/Acala we need to take into account exchange rate from TransactionPayment.tokenExchangeRate. Currently it is decided to overestimate fixed rate by 1.5 and implement dynamic rate in future.