### PR TITLE
Make RMRK Moonriver -> Statemine non-reserve w.r.t. to fee

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -12,7 +12,7 @@
       "multiLocation": {},
       "reserveFee": {
         "mode": {
-          "type": "standart"
+          "type": "standard"
         },
         "instructions": "xtokensReserve"
       }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -9,7 +9,13 @@
     },
     "KSM": {
       "chainId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-      "multiLocation": {}
+      "multiLocation": {},
+      "reserveFee": {
+        "mode": {
+          "type": "standart"
+        },
+        "instructions": "xtokensReserve"
+      }
     },
     "KSM-Statemine": {
       "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
@@ -233,7 +239,7 @@
                   "asset": {
                     "originAssetId": 2,
                     "destAssetId": 0,
-                    "location": "KSM-Statemine",
+                    "location": "KSM",
                     "locationPath": {
                       "type": "absolute"
                     }


### PR DESCRIPTION
xTokens [checks](https://github.com/open-web3-stack/open-runtime-module-library/blob/5792fd2bb3e6623e44ce56d18048a382f9f13b42/xtokens/src/lib.rs#L538) whether fee reserve is equal to sending reserve using ReserveProvider. For Moorniber, it is [configured](https://github.com/PureStake/moonbeam/blob/749749e4230fb097200c3f6c800127e319798f82/runtime/moonriver/src/xcm_config.rs#L472) to be AbsoluteAndRelativeReserve, which is a [wrapper](https://github.com/PureStake/moonbeam/blob/db1f064cd1b63102dc228e164a2e2898d502f45a/primitives/xcm/src/origin_conversion.rs#L76) around [RelativeReserveProvider](https://github.com/open-web3-stack/open-runtime-module-library/blob/a060819a722850ccaf945b78760c6c25f45a44e5/traits/src/location.rs#L66). RelativeReserveProvider uses chain part of MultiLocation to depermine reserve. Thus, when supplying relay chain multiplication of KSM, xTokens will determine relay chain as reserve and send KSM via relaychain
With current setup xTokens fails tx due to low fees: https://moonriver.subscan.io/extrinsic/2186657-3