### PR TITLE
Adding xcm transfers for Parallel Heiko

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -76,6 +76,13 @@
         "parachainId": 2092,
         "generalKey": "0x000c"
       }
+    },
+    "HKO": {
+      "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
+      "multiLocation": {
+        "parachainId": 2085,
+        "palletInstance": 4
+      }
     }
   },
   "instructions": {
@@ -334,6 +341,20 @@
                   "mode": {
                     "type": "proportional",
                     "value": "12350000000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
+                "assetId": 5,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "582784544553878381658112"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -751,6 +751,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 5,
+          "assetLocation": "KAR",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "baf5aabe40646d11f0ee8abbdc64f4a4b7674925cba08e4a05ff9ebed6e2126b",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "50000000000000002382364672"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -355,7 +355,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "582784544553878381658112"
+                    "value": "582784544553878"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -743,7 +743,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "3839999999999999463129088"
+                    "value": "384000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -123,7 +123,8 @@
     "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d": "200000000",
     "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a": "1000000000",
     "9af9a64e6e4da8e3073901c3ff0cc4c3aad9563786d89daf6ad820b6e14a0b8b": "200000000",
-    "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f": "1000000000"
+    "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f": "1000000000",
+    "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b": "150000000"
   },
   "chains": [
     {
@@ -720,6 +721,34 @@
                 }
               },
               "type": "xcmpallet-teleport"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
+      "assets": [
+        {
+          "assetId": 0,
+          "assetLocation": "HKO",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "0f62b701fb12d02237a33b84818c11f621653d2b1614c777973babf4652b535d",
+                "assetId": 5,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "3839999999999999463129088"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
             }
           ]
         }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -355,7 +355,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "582784544553878"
+                    "value": "582784544553879"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -803,7 +803,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "233113817821"
+                    "value": "11655690891078"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -124,7 +124,8 @@
     "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a": "1000000000",
     "9af9a64e6e4da8e3073901c3ff0cc4c3aad9563786d89daf6ad820b6e14a0b8b": "200000000",
     "68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f": "1000000000",
-    "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b": "150000000"
+    "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b": "150000000",
+    "0f62b701fb12d02237a33b84818c11f621653d2b1614c777973babf4652b535d": "1000000000"
   },
   "chains": [
     {
@@ -804,6 +805,34 @@
                   "mode": {
                     "type": "proportional",
                     "value": "11655690891078"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "chainId": "0f62b701fb12d02237a33b84818c11f621653d2b1614c777973babf4652b535d",
+      "assets": [
+        {
+          "assetId": 5,
+          "assetLocation": "HKO",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "349670726732328"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -252,6 +252,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 11,
+          "assetLocation": "HKO",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "349670726732328"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -386,6 +386,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 15,
+          "assetLocation": "HKO",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "349670726732327"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -772,6 +772,20 @@
                 }
               },
               "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
+                "assetId": 11,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "892857142857142"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
             }
           ]
         },

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -425,7 +425,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "349670726732327"
+                    "value": "349670726732328"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -609,7 +609,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "11655690891077567381504"
+                    "value": "11655690891077"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -766,7 +766,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "50000000000000002382364672"
+                    "value": "233113817821"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -790,7 +790,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "384000000000000000"
+                    "value": "426666666666667"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -600,6 +600,20 @@
                 }
               },
               "type": "xcmpallet-teleport"
+            },
+            {
+              "destination": {
+                "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "11655690891077567381504"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
             }
           ]
         },


### PR DESCRIPTION
## This PR adds some XCM transfers connected to Parallel Heiko network.
All this value were collected by script:
https://github.com/nova-wallet/nova-utils/pull/544

https://dotsama-channels.vercel.app/#/
<img width="808" alt="Screenshot 2022-07-13 at 14 15 26" src="https://user-images.githubusercontent.com/40560660/178721529-1de1cb3d-5e8b-4acc-a2b9-61fb9b5535c6.png">



### 1. HKO token was added
<details>
  <summary>Proofs</summary>

CurrencyId location - absolute
https://github.com/parallel-finance/parallel/blob/master/runtime/heiko/src/lib.rs#L377

<img width="746" alt="Screenshot 2022-07-13 at 13 21 25" src="https://user-images.githubusercontent.com/40560660/178711656-93e65987-d206-4270-bb1d-74782c0c1adc.png">

<img width="914" alt="Screenshot 2022-07-13 at 13 24 05" src="https://user-images.githubusercontent.com/40560660/178712184-a15d78af-b2f5-4b99-b4da-8cdb281bebe4.png">

</details>

### 2. networkBaseWeight for Parallel Heiko
<details>
  <summary>Proofs</summary>

https://github.com/parallel-finance/parallel/blob/master/runtime/heiko/src/lib.rs#L541

<img width="877" alt="Screenshot 2022-07-13 at 13 25 45" src="https://user-images.githubusercontent.com/40560660/178712517-dc770d76-b850-477c-bb33-0f9996e6181c.png">

</details>

### 3. networkBaseWeight for Turing
<details>
  <summary>Proofs</summary>

https://github.com/OAK-Foundation/OAK-blockchain/blob/master/runtime/turing/src/xcm_config.rs#L93

<img width="874" alt="Screenshot 2022-07-13 at 15 40 28" src="https://user-images.githubusercontent.com/40560660/178735706-da0d37d2-4a01-4226-a001-4905f7bc00fe.png">


</details>

# Directions:

## Karura

###  KAR Karura->Heiko ✅
<details>
  <summary>Proofs</summary>

https://github.com/nova-wallet/nova-utils/pull/580/files#diff-cacfb97494877710cb2b261071d443d1312b510fec22a7996d5ccf38da117afbR353

fee was calculated by this function:
https://github.com/nova-wallet/nova-utils/pull/544/files#diff-5fb50211bcb19bcac8a41a7de44c80795b35a9d810f94b7246b138dc535bdf1bR43

<img width="897" alt="Screenshot 2022-07-13 at 13 50 56" src="https://user-images.githubusercontent.com/40560660/178716886-4f73b28a-a4b6-44b4-9485-fc6c21da1cb3.png">

ExtrinsicBaseWeight = 85,795,000

base_weight = ((ExtrinsicBaseWeight / 1,000) * 1,000,000,000,000) / 1,000,000,000 = 85795000

fee_per_second = 1,000,000,000,000 / base_weight = 11655.6908910775686229

heiko_base_fee = base_tx_per_second * 1,000,000,000 = 11655690891077.5686229

kar_fee = heiko_base_fee * 50 = 582784544553878.431145

kar_fee.roundUp() = **582784544553879**


https://github.com/parallel-finance/parallel/blob/master/runtime/heiko/src/lib.rs#L1217
</details>

###  KAR Heiko->Karura ✅
<details>
  <summary>Proofs</summary>

https://github.com/nova-wallet/nova-utils/pull/580/files#diff-cacfb97494877710cb2b261071d443d1312b510fec22a7996d5ccf38da117afbR801

fee was calculated by this function:
https://github.com/nova-wallet/nova-utils/pull/544/files#diff-5fb50211bcb19bcac8a41a7de44c80795b35a9d810f94b7246b138dc535bdf1bR67

<img width="780" alt="Screenshot 2022-07-13 at 13 32 30" src="https://user-images.githubusercontent.com/40560660/178713746-f7416a39-b318-4eb6-8970-bd54e2d6c641.png">

ExtrinsicBaseWeight = 85,795,000

base_weight = ((ExtrinsicBaseWeight / 1,000) * 1,000,000,000,000) / 1,000,000,000 = 85795000

base_tx_per_second = 1,000,000,000,000 / base_weight = 11655.6908910775686229

fee_per_second = base_tx_per_second * 1,000,000,000 = 11655690891077.5686229

karura_base_fee. roundUp() = **11655690891078**

https://github.com/AcalaNetwork/Acala/blob/master/runtime/karura/src/xcm_config.rs#L131
</details>

---

###  HKO Heiko->Karura (can't calculate fee on Karura in HKO) 
https://github.com/AcalaNetwork/Acala/blob/master/runtime/karura/src/xcm_config.rs#L118

###  HKO Karura->Heiko ✅

<details>
  <summary>Proofs</summary>

https://github.com/nova-wallet/nova-utils/pull/580/files#diff-cacfb97494877710cb2b261071d443d1312b510fec22a7996d5ccf38da117afbR423

fee was calculated by this function:
https://github.com/nova-wallet/nova-utils/pull/544/files#diff-5fb50211bcb19bcac8a41a7de44c80795b35a9d810f94b7246b138dc535bdf1bR43

heiko_base_fee = base_tx_per_second * 1,000,000,000 = 11655690891077.5686229

fee_in_hko = heiko_base_fee * 30 = 349670726732327.058687
https://github.com/parallel-finance/parallel/blob/master/runtime/heiko/src/lib.rs#L1202

rounded value = **349670726732328**
</details>

---

## Turing

###  HKO Heiko->Turing ✅

<details>
  <summary>Proofs</summary>

https://github.com/nova-wallet/nova-utils/pull/580/files#diff-cacfb97494877710cb2b261071d443d1312b510fec22a7996d5ccf38da117afbR788

fee was calculated by this function:
https://github.com/nova-wallet/nova-utils/pull/544/files#diff-5fb50211bcb19bcac8a41a7de44c80795b35a9d810f94b7246b138dc535bdf1bR79

<img width="853" alt="Screenshot 2022-07-13 at 18 56 42" src="https://user-images.githubusercontent.com/40560660/178779776-df865826-13fd-4ff9-a99d-eeac61e9fe5f.png">


ExtrinsicBaseWeight = 125,000,000

base_weight = ((125,000,000 / 1000) * 1000000000000) / 1000000000 = 125000000

base_tx_per_second = 1000000000000 / 125000000 = 8000

fee_in_ksm = 8000 * 100000000000 * 16  = 12800000000000000

hko_fee = 12800000000000000 / 30 = 426666666666666.6666666666666667

https://github.com/OAK-Foundation/OAK-blockchain/blob/master/runtime/turing/src/xcm_config.rs#L247

rounded_fee = **426666666666667**

</details>

###  HKO Turing->Heiko ✅

<details>
  <summary>Proof</summary>

https://github.com/nova-wallet/nova-utils/pull/580/files#diff-cacfb97494877710cb2b261071d443d1312b510fec22a7996d5ccf38da117afbR265

fee was calculated by this function:
https://github.com/nova-wallet/nova-utils/pull/544/files#diff-5fb50211bcb19bcac8a41a7de44c80795b35a9d810f94b7246b138dc535bdf1bR43

<img width="897" alt="Screenshot 2022-07-13 at 13 50 56" src="https://user-images.githubusercontent.com/40560660/178716886-4f73b28a-a4b6-44b4-9485-fc6c21da1cb3.png">

ExtrinsicBaseWeight = 85,795,000

heiko_base_fee = base_tx_per_second * 1,000,000,000 = 11655690891077.5686229

fee_in_hko = heiko_base_fee * 30 = 349670726732327.058687

https://github.com/parallel-finance/parallel/blob/master/runtime/heiko/src/lib.rs#L1202

rounded value = **349670726732328**

</details>

---

## Moonriver

###  HKO Heiko->Moonriver ✅

<details>
  <summary>Proofs</summary>

https://github.com/nova-wallet/nova-utils/pull/580/files#diff-cacfb97494877710cb2b261071d443d1312b510fec22a7996d5ccf38da117afbR802

fee was calculated by this function:
https://github.com/nova-wallet/nova-utils/pull/544/files#diff-5fb50211bcb19bcac8a41a7de44c80795b35a9d810f94b7246b138dc535bdf1bR93

<img width="989" alt="Screenshot 2022-07-13 at 19 38 04" src="https://user-images.githubusercontent.com/40560660/178786045-56603823-ae35-4e1a-b79a-f1997bd80539.png">


</details>

###  HKO Moonriver->Heiko ✅

<details>
  <summary>Proof</summary>

https://github.com/nova-wallet/nova-utils/pull/580/files#diff-cacfb97494877710cb2b261071d443d1312b510fec22a7996d5ccf38da117afbR265

fee was calculated by this function:
https://github.com/nova-wallet/nova-utils/pull/544/files#diff-5fb50211bcb19bcac8a41a7de44c80795b35a9d810f94b7246b138dc535bdf1bR43

<img width="897" alt="Screenshot 2022-07-13 at 13 50 56" src="https://user-images.githubusercontent.com/40560660/178716886-4f73b28a-a4b6-44b4-9485-fc6c21da1cb3.png">

ExtrinsicBaseWeight = 85,795,000

heiko_base_fee = base_tx_per_second * 1,000,000,000 = 11655690891077.5686229

fee_in_hko = heiko_base_fee * 30 = 349670726732327.058687

https://github.com/parallel-finance/parallel/blob/master/runtime/heiko/src/lib.rs#L1202

rounded value = **349670726732328**

</details>

---

## Statemine

###  KSM Statemine->Heiko ✅

<details>
  <summary>Proofs</summary>

https://github.com/nova-wallet/nova-utils/pull/580/files#diff-cacfb97494877710cb2b261071d443d1312b510fec22a7996d5ccf38da117afbR654

fee was calculated by this function:
https://github.com/nova-wallet/nova-utils/pull/544/files#diff-5fb50211bcb19bcac8a41a7de44c80795b35a9d810f94b7246b138dc535bdf1bR43

<img width="897" alt="Screenshot 2022-07-13 at 13 50 56" src="https://user-images.githubusercontent.com/40560660/178716886-4f73b28a-a4b6-44b4-9485-fc6c21da1cb3.png">

ExtrinsicBaseWeight = 85,795,000

heiko_base_fee = base_tx_per_second * 1,000,000,000 = 11655690891077.5686229

rounded_fee = **11655690891078**

</details>
