### PR TITLE
Adding new tokens to Khala

### DIFF
--- a/chains/v4/chains_dev.json
+++ b/chains/v4/chains_dev.json
@@ -1723,6 +1723,92 @@
                 "precision": 12,
                 "priceId": "pha",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Phala.svg"
+            },
+            {
+                "assetId": 1,
+                "symbol": "KSM",
+                "precision": 12,
+                "type": "statemine",
+                "priceId": "kusama",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Kusama.svg",
+                "typeExtras": {
+                    "assetId": "0"
+                }
+            },
+            {
+                "assetId": 2,
+                "symbol": "KAR",
+                "precision": 12,
+                "type": "statemine",
+                "priceId": "karura",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Karura.svg",
+                "typeExtras": {
+                    "assetId": "1"
+                }
+            },
+            {
+                "assetId": 3,
+                "symbol": "BNC",
+                "precision": 12,
+                "type": "statemine",
+                "priceId": "bifrost-native-coin",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Bifrost.svg",
+                "typeExtras": {
+                    "assetId": "2"
+                }
+            },
+            {
+                "assetId": 4,
+                "symbol": "ZLK",
+                "precision": 18,
+                "priceId": "zenlink-network-token",
+                "type": "statemine",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/ZLK.svg",
+                "typeExtras": {
+                    "assetId": "3"
+                }
+            },
+            {
+                "assetId": 5,
+                "symbol": "aUSD",
+                "precision": 12,
+                "priceId": "tether",
+                "type": "statemine",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/AUSD.svg",
+                "typeExtras": {
+                    "assetId": "4"
+                }
+            },
+            {
+                "assetId": 6,
+                "symbol": "BSX",
+                "precision": 12,
+                "type": "statemine",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Basilisk.svg",
+                "typeExtras": {
+                    "assetId": "5"
+                }
+            },
+            {
+                "assetId": 6,
+                "symbol": "MOVR",
+                "precision": 18,
+                "priceId": "moonriver",
+                "type": "statemine",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Moonriver.svg",
+                "typeExtras": {
+                    "assetId": "6"
+                }
+            },
+            {
+                "assetId": 7,
+                "symbol": "HKO",
+                "precision": 12,
+                "type": "statemine",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/HKO.svg",
+                "typeExtras": {
+                    "assetId": "7"
+                }
             }
         ],
         "nodes": [

--- a/chains/v4/chains_dev.json
+++ b/chains/v4/chains_dev.json
@@ -1790,7 +1790,7 @@
                 }
             },
             {
-                "assetId": 6,
+                "assetId": 7,
                 "symbol": "MOVR",
                 "precision": 18,
                 "priceId": "moonriver",
@@ -1801,7 +1801,7 @@
                 }
             },
             {
-                "assetId": 7,
+                "assetId": 8,
                 "symbol": "HKO",
                 "precision": 12,
                 "type": "statemine",


### PR DESCRIPTION
This PR is adding new tokens for Khala network:
https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkhala-rpc.dwellir.com#/assets

<img width="1512" alt="Screenshot 2022-07-12 at 13 13 50" src="https://user-images.githubusercontent.com/40560660/178467496-f8de0c70-0543-4425-b835-ed94aee39c04.png">

<details>
  <summary>KSM</summary>

<img width="469" alt="Screenshot 2022-07-12 at 13 14 37" src="https://user-images.githubusercontent.com/40560660/178467643-8a2506ed-ccd8-430c-a5a0-99ae68ac054e.png">


</details>

<details>
  <summary>KAR</summary>

<img width="449" alt="Screenshot 2022-07-12 at 13 15 09" src="https://user-images.githubusercontent.com/40560660/178467730-33807899-b980-4a75-a92a-b858fce00351.png">

</details>

<details>
  <summary>BNC</summary>

<img width="444" alt="Screenshot 2022-07-12 at 13 15 45" src="https://user-images.githubusercontent.com/40560660/178467869-695d8b03-e9c5-478c-b370-0132c89c5796.png">

</details>

<details>
  <summary>ZLK</summary>

<img width="352" alt="Screenshot 2022-07-12 at 13 16 20" src="https://user-images.githubusercontent.com/40560660/178467990-44364520-d26c-49be-b269-94bcc27f97d8.png">

</details>


<details>
  <summary>aUSD</summary>

<img width="346" alt="Screenshot 2022-07-12 at 13 16 52" src="https://user-images.githubusercontent.com/40560660/178468087-4b7e3d62-cf4d-4fcc-bb63-69a373cf2969.png">

</details>

<details>
  <summary>BSX</summary>

<img width="355" alt="Screenshot 2022-07-12 at 13 17 50" src="https://user-images.githubusercontent.com/40560660/178468246-ef62c77c-640b-4d9e-a4be-dedc157dde96.png">

</details>

<details>
  <summary>MOVR</summary>

<img width="399" alt="Screenshot 2022-07-12 at 13 18 17" src="https://user-images.githubusercontent.com/40560660/178468327-2dfb7367-0929-4e31-9df5-095759e4e7f6.png">

</details>


<details>
  <summary>HKO</summary>

<img width="418" alt="Screenshot 2022-07-12 at 13 18 49" src="https://user-images.githubusercontent.com/40560660/178468424-6fb36c8a-0138-4db8-9a00-8b9d169a34d7.png">

</details>