### PR TITLE
Fix xcm for Parallel Heiko

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -267,7 +267,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "6993414534647"
+                    "value": "6993000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -379,7 +379,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "11655690891078"
+                    "value": "11655000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -425,7 +425,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "6993414534647"
+                    "value": "6993000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -776,7 +776,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "48000000000000"
+                    "value": "4800000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -813,7 +813,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "11655690891078"
+                    "value": "11655000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -841,7 +841,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "6993414534647"
+                    "value": "6993000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -81,7 +81,7 @@
       "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
       "multiLocation": {
         "parachainId": 2085,
-        "palletInstance": 4
+        "generalKey": "0x484b4f"
       }
     }
   },

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -379,7 +379,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "582784544553879"
+                    "value": "233113817822"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -648,20 +648,6 @@
                 }
               },
               "type": "xcmpallet-teleport"
-            },
-            {
-              "destination": {
-                "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
-                "assetId": 1,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "11655690891077"
-                  },
-                  "instructions": "xcmPalletDest"
-                }
-              },
-              "type": "xcmpallet"
             }
           ]
         },

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -841,7 +841,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "349670726732328"
+                    "value": "388523029703"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -267,7 +267,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "349670726732328"
+                    "value": "388523029703"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -425,7 +425,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "349670726732328"
+                    "value": "388523029703"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -267,7 +267,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "388523029703"
+                    "value": "6993414534647"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -425,7 +425,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "388523029703"
+                    "value": "6993414534647"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -776,7 +776,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "426666666666667"
+                    "value": "48000000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -841,7 +841,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "388523029703"
+                    "value": "6993414534647"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -379,7 +379,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "233113817822"
+                    "value": "11655690891078"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
This PR fixes:

## Fee estimation for KAR Karura-Heiko:
<details>
  <summary>Estimation</summary>

ExtrinsicBaseWeight = 85,795,000

base_weight = ((ExtrinsicBaseWeight / 1,000) * 1,000,000,000,000) / 1,000,000,000 = 85795000

fee_per_second = 1,000,000,000,000 / base_weight = 11655.6908910775686229

heiko_base_fee = base_tx_per_second * 1,000,000,000 = 11655690891077.5686229

kar_fee_in_heiko = heiko_base_fee / 50 = 233113817821,55136

https://github.com/parallel-finance/parallel/blob/master/runtime/heiko/src/lib.rs#L1217

kar_fee.roundUp() = **233113817822**

</details>

With that value we have a little underestimation:

-- | Transfered amount | Network fee | Cross-chain fee | Received amount
-- | -- | -- | -- | --
before | 1 | 0,00274 | 0,349267 | 1,34267
now | 1 | 0,00274 | 0,00013 | 0,99315



<details>
  <summary>Transaction details</summary>

https://karura.subscan.io/extrinsic/2269346-2

<img width="479" alt="Screenshot 2022-07-14 at 11 30 10" src="https://user-images.githubusercontent.com/40560660/178953698-1a56a771-f85a-44e8-a2a6-ecfd98729179.png">

</details>

## Remove KSM Statemine->Heiko case

## Fee estimation for HKO Karura and Moonriver -> Parallel Heiko transfers.
As it was calculated by multiply on [coefficient](https://github.com/parallel-finance/parallel/blob/master/runtime/heiko/src/lib.rs#L1202) rather than divide