### PR TITLE
Adding KSM xcm for much more networks

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -9,7 +9,13 @@
     },
     "KSM": {
       "chainId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
-      "multiLocation": {}
+      "multiLocation": {},
+      "reserveFee": {
+        "mode": {
+          "type": "standard"
+        },
+        "instructions": "xtokensReserve"
+      }
     },
     "KSM-Statemine": {
       "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -323,7 +323,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "11655690891078"
+                    "value": "233100000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -864,6 +864,20 @@
                 "fee": {
                   "mode": {
                     "type": "standard"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "0f62b701fb12d02237a33b84818c11f621653d2b1614c777973babf4652b535d",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "160000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -344,7 +344,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "4662000000"
+                    "value": "233100000000"
                   },
                   "instructions": "xcmPalletDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -951,20 +951,6 @@
                 }
               },
               "type": "xtokens"
-            },
-            {
-              "destination": {
-                "chainId": "0f62b701fb12d02237a33b84818c11f621653d2b1614c777973babf4652b535d",
-                "assetId": 1,
-                "fee": {
-                  "mode": {
-                    "type": "proportional",
-                    "value": "160000000000"
-                  },
-                  "instructions": "xtokensDest"
-                }
-              },
-              "type": "xtokens"
             }
           ]
         }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -13,7 +13,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "38620923660"
+          "value": "3862000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -497,7 +497,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "38620923660"
+                    "value": "3862000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -829,7 +829,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "38620923660"
+                    "value": "3862000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -945,7 +945,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "38620923660"
+                    "value": "3862000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -12,7 +12,8 @@
       "multiLocation": {},
       "reserveFee": {
         "mode": {
-          "type": "standard"
+          "type": "proportional",
+          "value": "38620923660"
         },
         "instructions": "xtokensReserve"
       }
@@ -495,7 +496,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "38620923660"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -826,7 +828,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "38620923660"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -941,7 +944,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "38620923660"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -335,6 +335,20 @@
                 }
               },
               "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "baf5aabe40646d11f0ee8abbdc64f4a4b7674925cba08e4a05ff9ebed6e2126b",
+                "assetId": 2,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": 11655000000000
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
             }
           ]
         }
@@ -446,6 +460,28 @@
                   "mode": {
                     "type": "proportional",
                     "value": "349670726732328"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 2,
+          "assetLocation": "KSM",
+          "assetLocationPath": {
+            "type": "relative"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "standard"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -315,6 +315,20 @@
                 }
               },
               "type": "xcmpallet-teleport"
+            },
+            {
+              "destination": {
+                "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "11655690891078"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
             }
           ]
         }
@@ -828,6 +842,28 @@
                   "mode": {
                     "type": "proportional",
                     "value": "11655690891078"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 1,
+          "assetLocation": "KSM",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "standard"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -349,6 +349,20 @@
                 }
               },
               "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "9af9a64e6e4da8e3073901c3ff0cc4c3aad9563786d89daf6ad820b6e14a0b8b",
+                "assetId": 2,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": 233100000000
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
             }
           ]
         }
@@ -791,6 +805,28 @@
                   "mode": {
                     "type": "proportional",
                     "value": "965646171792"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 2,
+          "assetLocation": "KSM",
+          "assetLocationPath": {
+            "type": "relative"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "standard"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -486,7 +486,7 @@
           "assetId": 2,
           "assetLocation": "KSM",
           "assetLocationPath": {
-            "type": "relative"
+            "type": "absolute"
           },
           "xcmTransfers": [
             {
@@ -817,7 +817,7 @@
           "assetId": 2,
           "assetLocation": "KSM",
           "assetLocationPath": {
-            "type": "relative"
+            "type": "absolute"
           },
           "xcmTransfers": [
             {

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -344,7 +344,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": 11655000000000
+                    "value": "4662000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -358,7 +358,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": 233100000000
+                    "value": "233100000000"
                   },
                   "instructions": "xcmPalletDest"
                 }


### PR DESCRIPTION
# This PR adds KSM xcm transfers for Heiko, Karura, Kintsugi

## Also it is updated KSM fee to proportional

calculated based on comment:
https://github.com/nova-wallet/nova-utils/pull/551

link to kusama polynomial func - https://github.com/paritytech/polkadot/blob/master/runtime/kusama/constants/src/lib.rs#L82
```
ExtrinsicBaseWeight = 86_309_000
UNITS = 1_000_000_000_000;
CENTS = UNITS / 30_000

p = CENTS ~ 33333333
q = 10 * 86_309_000 = 863090000
p / q = 0,03862092366

units_per_second = 0,03862092366 * 100000000000 ~ 3862000000
```


# Directions:

## [KSM Kusama<->Heiko](https://github.com/nova-wallet/nova-utils/pull/590/commits/02b347f90908b0855769af521d2cee71dee02b63)

### Kusama -> Heiko ✅
amount - 0.1
sent - 0.100139860000
**received - 0.1**
fee - 0.000139860000
<details>
  <summary>Tested</summary>

Extr:
https://kusama.subscan.io/extrinsic/13626496-6
Event:
https://parallel-heiko.subscan.io/extrinsic/1578832-1?event=1578832-4

<img width="513" alt="Screenshot 2022-07-19 at 11 00 17" src="https://user-images.githubusercontent.com/40560660/179699053-8c949e0e-ef88-491e-9ea4-ee2e773e357b.png">


</details>

### Heiko -> Kusama ✅
amount - 0.1
sent - 0.100015448000
**received - 0.100003924752**
fee - 0.000011523248
<details>
  <summary>Tested</summary>

Extr:
https://parallel-heiko.subscan.io/extrinsic/1578850-2
Event:
https://kusama.subscan.io/event?extrinsic=13626552-1&page=2

<img width="513" alt="Screenshot 2022-07-19 at 11 05 27" src="https://user-images.githubusercontent.com/40560660/179701297-50d95690-7310-4806-a961-f91f0b9f7f78.png">

</details>

## [KSM Kusama<->Karura](https://github.com/nova-wallet/nova-utils/pull/590/commits/8bada9771ff3039e678dc1c719b87f486fb24ddf) 

### Kusama -> Karura ✅

amount - 0.1
sent - 0.100186480000
**received - 0.100076402664**
fee - 0.000110077336

<details>
  <summary>Tested</summary>

Extr:
https://kusama.subscan.io/extrinsic/13628132-5
Event:
https://karura.subscan.io/extrinsic/2299180-1?event=2299180-36

<img width="513" alt="Screenshot 2022-07-19 at 11 14 54" src="https://user-images.githubusercontent.com/40560660/179702227-1cabcb6a-32e8-455b-b31d-20c2d61464c8.png">

</details>

### Karura -> Kusama ✅
amount - 0.1
sent - 0.100015448000
**received - 0.100003924752**
fee - 0.000011523248
<details>
  <summary>Tested</summary>

Extr:
https://karura.subscan.io/extrinsic/2298583-4
Event:
https://kusama.subscan.io/event?extrinsic=13626693-1&page=2

<img width="513" alt="Screenshot 2022-07-19 at 11 19 01" src="https://user-images.githubusercontent.com/40560660/179703151-a5cac1fd-0488-4e4e-bb55-d22124afff20.png">

</details>

## [KSM Kusama<->Kintsugi](https://github.com/nova-wallet/nova-utils/pull/590/commits/9183449c007b8adcb2b6aaaebc1da2a5ebc819d6)

### Kusama -> Kintsugi ✅
amount - 0.1
sent - 0.100186480000
**received - 0.1**
fee - 0.00018648
<details>
  <summary>Tested</summary>

Extr:
https://kusama.subscan.io/extrinsic/13626741-2
Event:
https://kintsugi.subscan.io/extrinsic/1169436-1?event=1169436-12

<img width="513" alt="Screenshot 2022-07-19 at 11 24 19" src="https://user-images.githubusercontent.com/40560660/179703600-40db77a2-bf6a-4c23-87fb-9cc8fb31fcea.png">

</details>

### Kintsugi -> Kusama ✅
amount - 0.1
sent - 0.100015448000
**received - 0.100003924752**
fee - 0.000011523248
<details>
  <summary>Tested</summary>

Extr:
https://kintsugi.subscan.io/extrinsic/1169498-2
Event:
https://kusama.subscan.io/event?extrinsic=13626956-1&page=2

<img width="513" alt="Screenshot 2022-07-19 at 11 45 54" src="https://user-images.githubusercontent.com/40560660/179708199-e2c0cbe1-34bf-42b3-8041-33d65139bebb.png">

</details>