### PR TITLE
Adding more xcm transfers for Moonriver

### DIFF
--- a/scripts/update_xcm_json_file.py
+++ b/scripts/update_xcm_json_file.py
@@ -235,7 +235,7 @@ def update_destinations(
             base_parameters=base_parameters,
             asset=asset,
             assetLocationPath=asset_location.get('assetLocationPath'),
-            destination=destination
+            already_added_destination=already_added_destination
         )
 
         for chain in xcm_object.chains:

--- a/scripts/update_xcm_json_file.py
+++ b/scripts/update_xcm_json_file.py
@@ -112,7 +112,10 @@ def build_xcm_transfer(
         destination_params = prompt(destination_questions(xcm_json))
 
         if (already_added_destination):
-            fee_mode = FeeMode(already_added_destination.destination.fee.mode)
+            fee_mode = FeeMode(
+                type=destination_params.get('fee_type'),
+                value=already_added_destination.destination.fee.mode.value
+            )
         else:
             fee_mode = FeeMode(
                 type=destination_params.get('fee_type')

--- a/scripts/update_xcm_json_file.py
+++ b/scripts/update_xcm_json_file.py
@@ -114,7 +114,7 @@ def build_xcm_transfer(
         if (already_added_destination):
             fee_mode = FeeMode(
                 type=destination_params.get('fee_type'),
-                value=already_added_destination.destination.fee.mode.value
+                value=str(already_added_destination.destination.fee.mode.value)
             )
         else:
             fee_mode = FeeMode(

--- a/scripts/utils/data_model/xcm_json_model.py
+++ b/scripts/utils/data_model/xcm_json_model.py
@@ -60,8 +60,8 @@ class Fee(BaseObject):
             raise Exception(
                 'Fee function is not available for network %s' % network.name)
 
-        self.mode.value = base_fee_and_multiplier(base_fee)
-        return self.mode.value
+        self.mode.value = str(base_fee_and_multiplier(base_fee))
+        return str(self.mode.value)
 
 
 class Destination(BaseObject):

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -226,6 +226,20 @@
                 }
               },
               "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": 8000000000000
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
             }
           ]
         },
@@ -751,6 +765,29 @@
                 "fee": {
                   "mode": {
                     "type": "standard"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 0,
+          "assetLocation": "BNC",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
+                "assetId": 5,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "35230000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -296,6 +296,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 3,
+          "assetLocation": "KINT",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "9af9a64e6e4da8e3073901c3ff0cc4c3aad9563786d89daf6ad820b6e14a0b8b",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "310800000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -816,6 +839,20 @@
                   "mode": {
                     "type": "proportional",
                     "value": "965646171792"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
+                "assetId": 3,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "1056250000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -234,7 +234,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": 8000000000000
+                    "value": "6400000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
## [Moonriver < BNC > Bifrost Kusama](https://github.com/nova-wallet/nova-utils/pull/615/commits/3c2a7349ce73cea724ceaeb6f9a4aee2c728aee7) ✅

<details>
  <summary>Tested</summary>

---

**Bifrost Kusama -> Moonriver**

amount - 1
sent - 1.028184000000
received - 1
fee - 0.028184000000

Extrinsic:
https://bifrost-kusama.subscan.io/extrinsic/2148065-2
Event:
https://moonriver.subscan.io/extrinsic/2244715-0?event=2244715-2


---

**Moonriver -> Bifrost Kusama**

amount - 1
sent - 1.005120000000
received - 1
fee - 0.00512

Extrinsic:
https://moonriver.subscan.io/extrinsic/2244840-3
Event:
https://bifrost-kusama.subscan.io/extrinsic/2148192-1?event=2148192-120

</details>


## [Moonriver < KINT > Kintsugi](https://github.com/nova-wallet/nova-utils/pull/615/commits/dc144c546e8b71dc89d5e8505c24e4b49e9c8000) ✅

<details>
  <summary>Tested</summary>

---

**Kintsugi-> Moonriver**

amount - 1
sent - 1.000845000000
received - 1
fee - 0.000845000000

Extrinsic:
https://kintsugi.subscan.io/extrinsic/1183541-2
Event:
https://moonriver.subscan.io/extrinsic/2244904-0?event=2244904-2


---

**Moonriver -> Kintsugi**

amount - 0.5
sent - 0.500248640000
received - 0.5
fee - 0.000248640000

Extrinsic:
https://moonriver.subscan.io/extrinsic/2244914-3
Event:
https://kintsugi.subscan.io/extrinsic/1183553-1?event=1183553-10

</details>

Also it fixes some problem in generation script