### PR TITLE
Update node order for Acala

### DIFF
--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -2022,6 +2022,10 @@
         ],
         "nodes": [
             {
+                "url": "wss://acala-rpc.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
                 "url": "wss://acala-rpc-0.aca-api.network",
                 "name": "Acala Foundation 0 node"
             },

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -2231,6 +2231,10 @@
         ],
         "nodes": [
             {
+                "url": "wss://acala-rpc.dwellir.com",
+                "name": "Dwellir node"
+            },
+            {
                 "url": "wss://acala-rpc-0.aca-api.network",
                 "name": "Acala Foundation 0 node"
             },
@@ -2253,10 +2257,6 @@
             {
                 "url": "wss://acala-polkadot.api.onfinality.io/public-ws",
                 "name": "OnFinality node"
-            },
-            {
-                "url": "wss://acala-rpc.dwellir.com",
-                "name": "Dwellir node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
This PR updates order for Acala nodes, as it has a problem for the last few days:

https://nova-wallet.github.io/test-runner/1222/#categories/0614ef0b64adf6a6ea133bb951b48ca3/c2c034ce1de0a585/history

<img width="1331" alt="Screenshot 2022-07-29 at 10 08 49" src="https://user-images.githubusercontent.com/40560660/181703551-ed282b8c-c68c-4727-8722-71c30ce7d609.png">

Replaced by Dwellir one:
https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Facala-rpc.dwellir.com#/explorer