### PR TITLE
Promote Composable icon fix

### DIFF
--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -3421,7 +3421,7 @@
                 "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-composable"
             }
         },
-        "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/Composable.svg",
+        "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/Composable.png",
         "addressPrefix": 49
     },
     {

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -231,6 +231,7 @@
                 "assetId": 1,
                 "symbol": "SIRI",
                 "precision": 10,
+                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
                  "type": "statemine",
                  "typeExtras": {
                      "assetId": "81"


### PR DESCRIPTION
- switch to png for Composable

<details>
  <summary>iOS</summary>

![Simulator Screen Shot - iPhone 12 Pro Max - 2022-07-29 at 12 39 30](https://user-images.githubusercontent.com/16337578/181731850-6ec89fd6-e67b-4c78-81c1-25fd183b7b8c.png)

</details>
<details>
  <summary>Android</summary>

![Screenshot_1659087427](https://user-images.githubusercontent.com/16337578/181731963-9cfadb01-0ff3-48f6-a06b-51b8ca9d3ada.png)

</details>

- fix Siri on dev