### PR TITLE
Adding token to xcm gh action step

### DIFF
--- a/.github/workflows/update_network_list.yaml
+++ b/.github/workflows/update_network_list.yaml
@@ -209,6 +209,7 @@ jobs:
         uses: actions/checkout@v1
         with:
           repository: nova-wallet/support-utils
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup version to variables
         run: |


### PR DESCRIPTION
To fetch data from personal repository it should be has Personal Access Token
https://github.com/nova-wallet/nova-utils/runs/7576758702?check_suite_focus=true

<img width="810" alt="Screenshot 2022-07-29 at 14 04 21" src="https://user-images.githubusercontent.com/40560660/181746278-825c2eaf-e40b-42f4-bce3-4fe67ff2bdf1.png">

