### PR TITLE
Fix BNC fee

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -42,7 +42,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "6400000000000"
+          "value": "512000000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -355,7 +355,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "6400000000000"
+                    "value": "512000000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -577,7 +577,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "6400000000000"
+                    "value": "512000000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1877,7 +1877,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "6400000000000"
+                    "value": "512000000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -42,7 +42,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "512000000000000"
+          "value": "926960000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -355,7 +355,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "512000000000000"
+                    "value": "926960000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -577,7 +577,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "512000000000000"
+                    "value": "926960000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1877,7 +1877,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "512000000000000"
+                    "value": "926960000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
BNC per second is **ksm_per_second * 80** - [source](https://github.com/bifrost-finance/bifrost/blob/develop/runtime/bifrost-kusama/src/lib.rs#L1112)
11_587_000_000_000 * 80 = **926_960_000_000_000**

base_weight = Balance::from(ExtrinsicBaseWeight::get()); = 86,298,000
base_tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight; = 1000000000000 / 86298000 ~ 11_587,75
fee_per_second = base_tx_per_second * (10**12  / 10) = 1_158_700_000_000_000
ksm_per_second = fee_per_second / 100 = 11_587_000_000_000
[source](https://github.com/bifrost-finance/bifrost/blob/d7bc68509d4b59d7a794f6267f9f135fafded320/runtime/bifrost-kusama/src/constants.rs#L61)