### PR TITLE
Fix BNC overestimation

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -42,7 +42,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "926960000000000"
+          "value": "9269600000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -355,7 +355,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "926960000000000"
+                    "value": "9269600000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -577,7 +577,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "926960000000000"
+                    "value": "9269600000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1877,7 +1877,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "926960000000000"
+                    "value": "9269600000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
Found a problem in bifrost calculation:
https://github.com/nova-wallet/support-utils/pull/2