### PR TITLE
Fix Bifrost BNC > Karura fee

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -375,7 +375,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "40000000000000"
+                    "value": "45189300000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1244,7 +1244,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "40000000000000"
+                    "value": "45189300000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -375,7 +375,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "30126200000000"
+                    "value": "40000000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1244,7 +1244,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "30126200000000"
+                    "value": "40000000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -375,7 +375,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "27972000000000"
+                    "value": "30126200000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1244,7 +1244,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "27972000000000"
+                    "value": "30126200000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
For Karura network must be used dex coefficient instead rate from code:
<img width="300" alt="Screenshot 2022-08-05 at 14 06 07" src="https://user-images.githubusercontent.com/40560660/183065072-8100853a-4a50-4c06-bb4b-c895149a46fb.png">

2,581,361,402,390,000,000 / 10^18 ~ 2.6 (Round Up, as exchange rate may be changed)

base_fee_coef = 11_587_000_000_000
coef_mutliplied_with_dex_rate = base_fee_coef * 2.6 =  30_126_200_000_000