### PR TITLE
Promote checked xcms to prod

### DIFF
--- a/xcm/v2/transfers.json
+++ b/xcm/v2/transfers.json
@@ -239,6 +239,20 @@
                 }
               },
               "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "11587000000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
             }
           ]
         },
@@ -457,6 +471,20 @@
                 }
               },
               "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "11587000000000"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
             }
           ]
         }
@@ -633,6 +661,20 @@
                   "mode": {
                     "type": "proportional",
                     "value": "233100000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "11587000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -963,6 +1005,99 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 1,
+          "assetLocation": "KSM",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "38620000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "baf5aabe40646d11f0ee8abbdc64f4a4b7674925cba08e4a05ff9ebed6e2126b",
+                "assetId": 2,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "233100000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "9af9a64e6e4da8e3073901c3ff0cc4c3aad9563786d89daf6ad820b6e14a0b8b",
+                "assetId": 2,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "233100000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "401a1f9dca3da46f5c4091016c8a2f26dcea05865116b286f60f668207d1474b",
+                "assetId": 2,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "130000000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "64a1c658a48b2e70a7fb1ad4c39eea35022568c20fc44a6e2e3d0a57aee6053b",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "233100000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "0f62b701fb12d02237a33b84818c11f621653d2b1614c777973babf4652b535d",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "160000000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -1063,6 +1198,20 @@
                   "mode": {
                     "type": "proportional",
                     "value": "233100000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "11587000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1221,6 +1370,20 @@
                   "mode": {
                     "type": "proportional",
                     "value": "233100000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "11587000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
Test results:
## Moonriver < KSM > Bifrost ✅ 

<details>
  <summary>Test results</summary>

Moonriver KSM > Bifrost

amount - 0.001
sent - 0.01042
received - 0.0103

Extrinsic:
https://moonriver.subscan.io/extrinsic/0xcb6bebdad3f03c032f771269a5972f9b71d6ea37ea81341dd9cd9aad5c526b95
Event:
https://bifrost-kusama.subscan.io/extrinsic/2223277-1?event=2223277-4

Moonriver < KSM Bifrost 

amount - 0.001
sent - 0.00126
received - 0.00112

Extrinsic:
https://bifrost-kusama.subscan.io/extrinsic/0x13f498798ed64c7ad9f393fc46c1404277687b4b112117f4f6e2188e1edf2e2b
Event:
https://moonriver.subscan.io/extrinsic/2318870-0?event=2318870-3

</details>

## Kusama < KSM > Bifrost ✅ 

<details>
  <summary>Test results</summary>

Kusama KSM > Bifrost (safe overestimate)

amount - 0.001
sent - 0.01034
received - 0.01018 

Extrinsic:
https://kusama.subscan.io/extrinsic/0x6cfc7f0e1d463c5142265f69d18569c9ff2afcd528ea1f0f1aa1a8fbf8271516
Event:
https://bifrost-kusama.subscan.io/extrinsic/2223318-1?event=2223318-4

Kusama < KSM Bifrost

amount - 0.02
sent - 0.02016
received - 0.02014

Extrinsic:
https://bifrost-kusama.subscan.io/extrinsic/0x5bdb2c0ea3b237c26f91466d82b5b25bdf3f2b6e27a5bc04427c278779db5336
Event:
https://kusama.subscan.io/extrinsic/13858080-1?event=13858080-40

</details>

## Karura < KSM > Bifrost ✅ 

<details>
  <summary>Test results</summary>

Karura KSM > Bifrost 

amount - 0.01
sent - 0.01943
received - 0.01931

Extrinsic:
https://karura.subscan.io/extrinsic/0x7921765e3a78049e88d618e8a23c0bc94ca3f362bb7c5edf1ee2502bb70d6f73
 Event:
https://bifrost-kusama.subscan.io/extrinsic/2223825-1?event=2223825-4

Karura < KSM Bifrost 

amount -0.02
sent - 0.02035
received - 0.02022

Extrinsic:
https://bifrost-kusama.subscan.io/extrinsic/0x3d8d860eb58e19164121dee1014929667c76eb25efb5adf450522d5ff0b08b0f
Event:
https://karura.subscan.io/extrinsic/2391909-1?event=2391909-8

</details>

## Kintsugi < KSM > Bifrost ✅ 

<details>
  <summary>Test results</summary>

Kintsugi KSM > Bifrost 

amount - 0.01
sent - 0.01035
received - 0.01013

Extrinsic:
https://bifrost-kusama.subscan.io/extrinsic/0x0c63e18eed25efebb3590548be1be93def4fbc034eba483c94abe3df4835e3ab
 Event:
https://kintsugi.subscan.io/extrinsic/1256669-1?event=1256669-10

Kintsugi < KSM Bifrost 

amount - 0.01
sent - 0.01942
received - 0.01931

Extrinsic:
https://kintsugi.subscan.io/extrinsic/0x393b5f773ce11bf68bbb76902703b51ddcc3440c7edef5dcbee992f72d862d28
Event:
https://bifrost-kusama.subscan.io/extrinsic/2224213-1?event=2224213-4

</details>

## Parallel Heiko < KSM > Bifrost ✅

<details>
  <summary>Test results</summary>

Parallel Heiko KSM > Bifrost 

amount - 0.01
sent - 0.0103
received - 0.01012

Extrinsic:
https://bifrost-kusama.subscan.io/extrinsic/0xd92defc22fe13fa8ea96da7ecb6defe1e1a6e1e15209d95ec8c6910c88a6b04d
 Event:
https://parallel-heiko.subscan.io/extrinsic/1672875-1?event=1672875-5

Parallel Heiko < KSM Bifrost 

amount - 0.01
sent - 0.01942
received - 0.0193

Extrinsic:
https://parallel-heiko.subscan.io/extrinsic/0x5a3ccccb088a7a7e97afa7bc956b64a743a948ac359868852097b6afe0934d27
Event:
https://bifrost-kusama.subscan.io/extrinsic/2224294-1?event=2224294-4

</details>

## Turing < KSM Bifrost ✅

<details>
  <summary>Test results</summary>

Turing < KSM Bifrost 

amount - 0.01
sent - 0.01079
received - 0.01012

Extrinsic:
https://bifrost-kusama.subscan.io/extrinsic/0x27059b0dfab22481d7fb521f9ae5e397c3c144c8cd48661812e0ef4ab6537f4e
Event:
https://turing.subscan.io/extrinsic/663649-0?event=663649-4

</details>