### PR TITLE
Promote Acala and Moonbeam new tokens

### DIFF
--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -803,6 +803,28 @@
                 "typeExtras": {
                     "assetId": "32615670524745285411807346420584982855"
                 }
+            },
+            {
+                "assetId": 5,
+                "symbol": "xcINTR",
+                "precision": 10,
+                "type": "statemine",
+                "priceId": "interlay",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Interlay.svg",
+                "typeExtras": {
+                    "assetId": "101170542313601871197860408087030232491"
+                }
+            },
+            {
+                "assetId": 6,
+                "symbol": "xciBTC",
+                "precision": 8,
+                "type": "statemine",
+                "priceId": "bitcoin",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/interBTC.svg",
+                "typeExtras": {
+                    "assetId": "120637696315203257380661607956669368914"
+                }
             }
         ],
         "nodes": [
@@ -2026,6 +2048,61 @@
                     "currencyIdScale": "0x0300000000",
                     "currencyIdType": "acala_primitives.currency.CurrencyId",
                     "existentialDeposit": "100000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 9,
+                "symbol": "INTR",
+                "precision": 10,
+                "type": "orml",
+                "priceId": "interlay",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Interlay.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x050400",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "1000000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 10,
+                "symbol": "ASTR",
+                "precision": 18,
+                "type": "orml",
+                "priceId": "astar",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Astar.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x050200",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "100000000000000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 15,
+                "symbol": "EQ",
+                "precision": 9,
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Equilibrium.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x050700",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "1000000000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 16,
+                "symbol": "iBTC",
+                "precision": 8,
+                "type": "orml",
+                "priceId": "bitcoin",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/interBTC.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x050300",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "100",
                     "transfersEnabled": true
                 }
             }

--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -2080,7 +2080,7 @@
                 }
             },
             {
-                "assetId": 15,
+                "assetId": 11,
                 "symbol": "EQ",
                 "precision": 9,
                 "type": "orml",
@@ -2093,7 +2093,7 @@
                 }
             },
             {
-                "assetId": 16,
+                "assetId": 12,
                 "symbol": "iBTC",
                 "precision": 8,
                 "type": "orml",

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -2258,7 +2258,7 @@
                 }
             },
             {
-                "assetId": 15,
+                "assetId": 11,
                 "symbol": "EQ",
                 "precision": 9,
                 "type": "orml",
@@ -2271,7 +2271,7 @@
                 }
             },
             {
-                "assetId": 16,
+                "assetId": 12,
                 "symbol": "iBTC",
                 "precision": 8,
                 "type": "orml",


### PR DESCRIPTION
Token parameters proofs:
https://github.com/nova-wallet/nova-utils/pull/681

## Acala
### INTR ✅

<details>
  <summary>Proof</summary>

<img width="559" alt="Screenshot 2022-08-05 at 18 57 42" src="https://user-images.githubusercontent.com/40560660/183115613-0c07c635-5c53-4984-a844-204b1592a030.png">

</details>

### iBTC ✅

<details>
  <summary>Proof</summary>

<img width="559" alt="Screenshot 2022-08-05 at 18 58 20" src="https://user-images.githubusercontent.com/40560660/183115713-3b32d205-b309-4b35-9651-08d5054cdaff.png">

</details>

### ASTR ✅

<details>
  <summary>Proof</summary>

<img width="559" alt="Screenshot 2022-08-05 at 18 58 49" src="https://user-images.githubusercontent.com/40560660/183115814-dc9418c6-98c6-4c4f-9501-6ef31246110e.png">

</details>

### EQ ✅

<details>
  <summary>Proof</summary>

<img width="559" alt="Screenshot 2022-08-05 at 18 59 15" src="https://user-images.githubusercontent.com/40560660/183115912-b31a4db7-fd2c-4ae8-a2f8-b112efe0a98a.png">


</details>

## Moonbeam
### xcINTR ✅

<details>
  <summary>Proof</summary>

<img width="559" alt="Screenshot 2022-08-05 at 18 59 44" src="https://user-images.githubusercontent.com/40560660/183116008-514f44c2-f5aa-4132-b2e5-a7801f9862a7.png">


</details>

### xciBTC ✅

<details>
  <summary>Proof</summary>

<img width="559" alt="Screenshot 2022-08-05 at 19 02 45" src="https://user-images.githubusercontent.com/40560660/183116467-c7cd39a7-253b-4c60-925f-3beefb7c6615.png">


</details>

---
Also that PR fixes assetId order for chains_dev.json which was made in https://github.com/nova-wallet/nova-utils/pull/681 as result of deleting [Remove WETH, USDCet, WBTC, DAI](https://github.com/nova-wallet/nova-utils/pull/681/commits/5b2f63724f11e545a6b73854a58d3a928b09701c)