### PR TITLE
Fix fee for INTR and iBTC

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -1093,7 +1093,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "1158700"
+                    "value": "116"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1265,7 +1265,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "3209201422318"
+                    "value": "125160"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2300,7 +2300,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "3209201422318"
+                    "value": "125160"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2314,7 +2314,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "1158700"
+                    "value": "116"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -1056,7 +1056,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "11587000000000"
+                    "value": "115870000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2277,7 +2277,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "11587000000000"
+                    "value": "115870000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
Before that fix (11_587_000_000_000):
<details>
  <summary>Spoiler!</summary>

Interlay INTR > Acala

amount - 1
sent - 1.9269600000
received - 1.9176904000

Extr:
https://interlay.subscan.io/extrinsic/944999-2
Event:
https://acala.subscan.io/extrinsic/1608239-1?event=1608239-8

</details>

After fix (115_870_000_000):
<details>
  <summary>Spoiler!</summary>

amount - 1
sent - 1.0092696000
received - 1

Extr:
https://interlay.subscan.io/extrinsic/945482-2
Event:
https://acala.subscan.io/extrinsic/1608726-1?event=1608726-7

</details>

Calculation:
Base on [this](https://github.com/AcalaNetwork/Acala/blob/master/runtime/acala/src/xcm_config.rs#L149)

BaseRate = aca_per_second

base_weight = 86_298_000
base_tx_per_second = 1_000_000_000_000 / base_weight;
aca_per_second = base_tx_per_second * (1*10^12 / 100 / 10) = 11 587,7540615078 * 1_000_000_000 = 11_587_000_000_000

final_coeff = BuyWeightRateOfForeignAsset * aca_per_second = (1_000_000_000 / 100_000_000_000) * 11_587_000_000_000 = **115_870_000_000**

<details>
  <summary>Spoiler!</summary>

<img width="200" alt="Screenshot 2022-08-09 at 19 45 23" src="https://user-images.githubusercontent.com/40560660/183709801-5198dfbc-d504-4890-ae9a-86cc6016f449.png">

<img width="200" alt="Screenshot 2022-08-09 at 19 45 12" src="https://user-images.githubusercontent.com/40560660/183709821-3b9033ab-cf9a-4701-a6e3-ce71765ffe91.png">


</details>
