### PR TITLE
Fix fee for MOVR

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -42,7 +42,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "5000000000000000"
+          "value": "50000000000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -1344,7 +1344,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "5000000000000000"
+                    "value": "50000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1939,7 +1939,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "5000000000000000"
+                    "value": "50000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2032,7 +2032,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "5000000000000000"
+                    "value": "50000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -1386,7 +1386,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "1158700000000"
+                    "value": "115870000000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -41,7 +41,8 @@
       },
       "reserveFee": {
         "mode": {
-          "type": "standard"
+          "type": "proportional",
+          "value": "1000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -1342,7 +1343,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "1000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1936,7 +1938,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "1000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2028,7 +2031,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "1000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -42,7 +42,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "1000000000"
+          "value": "5000000000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -1344,7 +1344,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "1000000000"
+                    "value": "5000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1939,7 +1939,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "1000000000"
+                    "value": "5000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -2032,7 +2032,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "1000000000"
+                    "value": "5000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
That PR changes fee for MOVR from standard to proportional
Fee was calculated based on - https://github.com/PureStake/moonbeam/blob/54e40e2aa3f1f41a45a7df067a6ac6a0256cda6a/runtime/moonbase/src/lib.rs#L305

Also was changed fee for Karura network.

Tested:

### Bifrost MOVR > Moonriver: ✅

amount - 0.001
sent - 0.001040000000000000
received - 0.001

Extr:
https://bifrost-kusama.subscan.io/extrinsic/2265646-2
Event:
https://moonriver.subscan.io/extrinsic/2360746-0?event=2360746-4

### Bifrost MOVR > Karura: ✅

amount - 0.01
sent - 0.010132696000000000
received - 0.01

Extr:
https://bifrost-kusama.subscan.io/extrinsic/2270046-2
Event:
https://karura.subscan.io/extrinsic/2437941-1?event=2437941-7