### PR TITLE
Adding reserveFee for ASTR

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -180,6 +180,13 @@
       "multiLocation": {
         "parachainId": 2006,
         "palletInstance": 31
+      },
+      "reserveFee": {
+        "mode": {
+          "type": "proportional",
+          "value": "11587754"
+        },
+        "instructions": "xtokensReserve"
       }
     }
   },


### PR DESCRIPTION
reserveFee was calculated based on [method](https://github.com/nova-wallet/nova-utils/pull/551)
source:
https://github.com/AstarNetwork/Astar/blob/master/runtime/astar/src/lib.rs#L599

```rust
p = 1_000_000_000_000_000
q = 86_298_000

p / q = 11587754
```
milliastar = https://github.com/AstarNetwork/Astar/blob/master/runtime/astar/src/lib.rs#L63

<img width="907" alt="Screenshot 2022-08-15 at 13 05 21" src="https://user-images.githubusercontent.com/40560660/184616800-1eecec9a-4e51-4573-bcfd-22c798b9eb09.png">

