### PR TITLE
Adding new destinations for GLMR

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -1060,6 +1060,20 @@
                 }
               },
               "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "fc41b9bd8ef8fe53d58c7ea67c794c7ec9a73daf05e6d54b14ff6342c99ba64c",
+                "assetId": 5,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "115870000000000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
             }
           ]
         },

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -2326,6 +2326,20 @@
                 }
               },
               "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "fc41b9bd8ef8fe53d58c7ea67c794c7ec9a73daf05e6d54b14ff6342c99ba64c",
+                "assetId": 5,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "115870000000000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
             }
           ]
         },


### PR DESCRIPTION
This PR adds missing GLMR destinations:
<img width="799" alt="Screenshot 2022-08-17 at 09 50 08" src="https://user-images.githubusercontent.com/40560660/185053496-aed43ef2-d9b1-4a66-82c1-c4c36abb4345.png">

- [Moonbeam GLMR > Acala](https://github.com/nova-wallet/nova-utils/pull/712/commits/b112e0aea959aff04d8176224b2b24d70de43e18)
- [Acala GLMR > Moonbeam, Parallel](https://github.com/nova-wallet/nova-utils/pull/712/commits/61c6e1dccb7f0a0e2a5626459053fa64cc2f3378)
- [Parallel GLMR > Acala](https://github.com/nova-wallet/nova-utils/pull/712/commits/4a069c842c23da0f30e4dddfd9f77e812638d56f)