### PR TITLE
fix GLMR fee on Acala

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -1124,7 +1124,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "115870000000000000"
+                    "value": "11587000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
Fix for GLMR fee on Acala:


Moonbeam GLMR > Acala

amount - 0.1
sent - 0.100092696000000000
received - 0.090823096000000000

fee - 9269600000000000

Extrinsic:
https://moonbeam.subscan.io/extrinsic/0x8ba865e43141d2064d94486eb58aa11b7655e5c2528b19211fe643d34503d315
Event:
https://acala.subscan.io/extrinsic/1662496-1?event=1662496-3
