### PR TITLE
Fix fee for GLMR

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -95,6 +95,13 @@
       "multiLocation": {
         "parachainId": 2004,
         "palletInstance": 10
+      },
+      "reserveFee": {
+        "mode": {
+          "type": "proportional",
+          "value": "100000000000000000"
+        },
+        "instructions": "xtokensReserve"
       }
     },
     "RMRK": {
@@ -2223,7 +2230,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "100000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -98,8 +98,7 @@
       },
       "reserveFee": {
         "mode": {
-          "type": "proportional",
-          "value": "100000000000000000"
+          "type": "standard"
         },
         "instructions": "xtokensReserve"
       }
@@ -2230,8 +2229,7 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "proportional",
-                    "value": "100000000000000000"
+                    "type": "standard"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
Source : 
https://github.com/PureStake/moonbeam/blob/master/runtime/moonbeam/src/lib.rs#L303

```RUST
pub const TRANSACTION_BYTE_FEE: Balance = 1 * GIGAWEI * SUPPLY_FACTOR;

pub const GIGAWEI: Balance = 1_000_000_000;

pub const SUPPLY_FACTOR: Balance = 100;

fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
		smallvec![
			WeightToFeeCoefficient {
				degree: 1,
				coeff_frac: Perbill::zero(),
				coeff_integer: currency::TRANSACTION_BYTE_FEE,
				negative: false,
			},
			WeightToFeeCoefficient {
				degree: 3,
				coeff_frac: Perbill::zero(),
				coeff_integer: 1 * currency::SUPPLY_FACTOR,
				negative: false,
			},
		]

1 * 100^3 = 1_000_000
1 * 1_000_000_000 * 100 = 100_000_000_000

final_coefficient = 100000000000000000
```

Can't use standard type of fee calculation as it still unresolve for iOS:
https://app.clickup.com/t/2vcckpx