### PR TITLE
Fix GM tokens precision

### DIFF
--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -3971,7 +3971,7 @@
             {
                 "assetId": 1,
                 "symbol": "GM",
-                "precision": 0,
+                "precision": 12,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/GM.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -3984,7 +3984,7 @@
             {
                 "assetId": 2,
                 "symbol": "GN",
-                "precision": 0,
+                "precision": 12,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/GN.svg",
                 "type": "orml",
                 "typeExtras": {

--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -3971,7 +3971,7 @@
             {
                 "assetId": 1,
                 "symbol": "GM",
-                "precision": 12,
+                "precision": 0,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/GM.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -3984,7 +3984,7 @@
             {
                 "assetId": 2,
                 "symbol": "GN",
-                "precision": 12,
+                "precision": 0,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/GN.svg",
                 "type": "orml",
                 "typeExtras": {

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -4452,7 +4452,7 @@
             {
                 "assetId": 1,
                 "symbol": "GM",
-                "precision": 0,
+                "precision": 12,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/GM.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -4465,7 +4465,7 @@
             {
                 "assetId": 2,
                 "symbol": "GN",
-                "precision": 0,
+                "precision": 12,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/GN.svg",
                 "type": "orml",
                 "typeExtras": {

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -4452,7 +4452,7 @@
             {
                 "assetId": 1,
                 "symbol": "GM",
-                "precision": 12,
+                "precision": 0,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/GM.svg",
                 "type": "orml",
                 "typeExtras": {
@@ -4465,7 +4465,7 @@
             {
                 "assetId": 2,
                 "symbol": "GN",
-                "precision": 12,
+                "precision": 0,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/GN.svg",
                 "type": "orml",
                 "typeExtras": {


### PR DESCRIPTION
GM and GN tokens were set to have 12 decimals, when in reality these tokens have no decimal points.