### PR TITLE
Promote Amplitude network

### DIFF
--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -4014,5 +4014,64 @@
         },
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/GM.svg",
         "addressPrefix": 7013
+    },
+    {
+        "chainId": "cceae7f3b9947cdb67369c026ef78efa5f34a08fe5808d373c04421ecf4f1aaf",
+        "parentId": "b0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe",
+        "name": "Amplitude",
+        "assets": [
+            {
+                "assetId": 0,
+                "symbol": "AMPE",
+                "precision": 12,
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Amplitude.svg"
+            }
+        ],
+        "nodes": [
+            {
+                "url": "wss://pencol-kus-01.pendulumchain.tech",
+                "name": "PendulumChain node"
+            }
+        ],
+        "types": {
+            "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/amplitude.json",
+            "overridesCommon": true
+        },
+        "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/Amplitude.svg",
+        "addressPrefix": 57
+    },
+    {
+        "chainId": "6859c81ca95ef624c9dfe4dc6e3381c33e5d6509e35e147092bfbc780f777c4e",
+        "name": "Ternoa",
+        "assets": [
+            {
+                "assetId": 0,
+                "symbol": "CAPS",
+                "priceId": "coin-capsule",
+                "staking": "relaychain",
+                "precision": 18,
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Ternoa.svg"
+            }
+        ],
+        "nodes": [
+            {
+                "url": "wss://mainnet.ternoa.network",
+                "name": "CapsuleCorp node"
+            }
+        ],
+        "explorers": [
+            {
+                "name": "Ternoa explorer",
+                "extrinsic": "https://explorer.ternoa.com/extrinsic/{hash}",
+                "account": "https://explorer.ternoa.com/account/{address}",
+                "event": null
+            }
+        ],
+        "types": {
+            "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/ternoa.json",
+            "overridesCommon": true
+        },
+        "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/Ternoa.svg",
+        "addressPrefix": 42
     }
 ]

--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -4039,38 +4039,5 @@
         },
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/Amplitude.svg",
         "addressPrefix": 57
-    },
-    {
-        "chainId": "6859c81ca95ef624c9dfe4dc6e3381c33e5d6509e35e147092bfbc780f777c4e",
-        "name": "Ternoa",
-        "assets": [
-            {
-                "assetId": 0,
-                "symbol": "CAPS",
-                "priceId": "coin-capsule",
-                "precision": 18,
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Ternoa.svg"
-            }
-        ],
-        "nodes": [
-            {
-                "url": "wss://mainnet.ternoa.network",
-                "name": "CapsuleCorp node"
-            }
-        ],
-        "explorers": [
-            {
-                "name": "Ternoa explorer",
-                "extrinsic": "https://explorer.ternoa.com/extrinsic/{hash}",
-                "account": "https://explorer.ternoa.com/account/{address}",
-                "event": null
-            }
-        ],
-        "types": {
-            "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/ternoa.json",
-            "overridesCommon": true
-        },
-        "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/Ternoa.svg",
-        "addressPrefix": 42
     }
 ]

--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -4048,7 +4048,6 @@
                 "assetId": 0,
                 "symbol": "CAPS",
                 "priceId": "coin-capsule",
-                "staking": "relaychain",
                 "precision": 18,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Ternoa.svg"
             }


### PR DESCRIPTION
<details>
  <summary> iOS </summary>

![photo_2022-08-30_11-33-17](https://user-images.githubusercontent.com/16337578/187389858-2b977147-4773-41b6-b58f-1ca9c2b22363.jpg)
![photo_2022-08-30_11-33-11](https://user-images.githubusercontent.com/16337578/187389861-01ce4a72-fdc3-474e-b90f-f4d2a98d5234.jpg)


</details>
<details>
  <summary>Android</summary>

![photo_2022-08-30_11-33-19](https://user-images.githubusercontent.com/16337578/187389929-ec4396c8-4050-4d52-97ea-6517c27c551a.jpg)
![photo_2022-08-30_11-33-21](https://user-images.githubusercontent.com/16337578/187389923-cf8eee95-2761-4a2e-b4de-79d43948b8ef.jpg)

</details>

removed Ternoa staking until [issue](https://app.clickup.com/t/2wmf03y) is fixed

Ternoa moved to this [PR](https://github.com/nova-wallet/nova-utils/pull/765) for promotion