### PR TITLE
Fix currencyId for Turing

### DIFF
--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -232,7 +232,7 @@
                 "assetId": 1,
                 "symbol": "SIRI",
                 "precision": 10,
-                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
                 "type": "statemine",
                 "typeExtras": {
                      "assetId": "81"

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -3664,7 +3664,7 @@
                  "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Kusama.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x01",
+                    "currencyIdScale": "0x01000000",
                     "currencyIdType": "turing_runtime.CurrencyId",
                     "existentialDeposit": "100000000",
                     "transfersEnabled": true
@@ -3678,7 +3678,7 @@
                  "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/AUSD.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x02",
+                    "currencyIdScale": "0x02000000",
                     "currencyIdType": "turing_runtime.CurrencyId",
                     "existentialDeposit": "10000000000",
                     "transfersEnabled": true
@@ -3692,7 +3692,7 @@
                  "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Karura.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x03",
+                    "currencyIdScale": "0x03000000",
                     "currencyIdType": "turing_runtime.CurrencyId",
                     "existentialDeposit": "100000000000",
                     "transfersEnabled": true
@@ -3705,7 +3705,7 @@
                  "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/LKSM.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x04",
+                    "currencyIdScale": "0x04000000",
                     "currencyIdType": "turing_runtime.CurrencyId",
                     "existentialDeposit": "500000000",
                     "transfersEnabled": true
@@ -3718,7 +3718,7 @@
                  "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/HKO.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x05",
+                    "currencyIdScale": "0x05000000",
                     "currencyIdType": "turing_runtime.CurrencyId",
                     "existentialDeposit": "500000000000",
                     "transfersEnabled": true
@@ -3731,7 +3731,7 @@
                  "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/sKSM.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x06",
+                    "currencyIdScale": "0x06000000",
                     "currencyIdType": "turing_runtime.CurrencyId",
                     "existentialDeposit": "500000000",
                     "transfersEnabled": true
@@ -3745,7 +3745,7 @@
                  "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Phala.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x07",
+                    "currencyIdScale": "0x07000000",
                     "currencyIdType": "turing_runtime.CurrencyId",
                     "existentialDeposit": "10000000000",
                     "transfersEnabled": true

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -233,10 +233,10 @@
                 "symbol": "SIRI",
                 "precision": 10,
                  "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Default.svg",
-                 "type": "statemine",
-                 "typeExtras": {
+                "type": "statemine",
+                "typeExtras": {
                      "assetId": "81"
-                 }
+                }
             }
         ],
         "nodes": [
@@ -3661,11 +3661,11 @@
                 "symbol": "KSM",
                 "precision": 12,
                 "priceId": "kusama",
-                 "type": "orml",
+                "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Kusama.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x01000000",
-                    "currencyIdType": "turing_runtime.CurrencyId",
+                    "currencyIdType": "u32",
                     "existentialDeposit": "100000000",
                     "transfersEnabled": true
                 }
@@ -3675,11 +3675,11 @@
                 "symbol": "aUSD",
                 "precision": 12,
                 "priceId": "acala-dollar",
-                 "type": "orml",
+                "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/AUSD.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x02000000",
-                    "currencyIdType": "turing_runtime.CurrencyId",
+                    "currencyIdType": "u32",
                     "existentialDeposit": "10000000000",
                     "transfersEnabled": true
                 }
@@ -3689,11 +3689,11 @@
                 "symbol": "KAR",
                 "precision": 12,
                 "priceId": "karura",
-                 "type": "orml",
+                "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Karura.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x03000000",
-                    "currencyIdType": "turing_runtime.CurrencyId",
+                    "currencyIdType": "u32",
                     "existentialDeposit": "100000000000",
                     "transfersEnabled": true
                 }
@@ -3702,11 +3702,11 @@
                 "assetId": 4,
                 "symbol": "LKSM",
                 "precision": 12,
-                 "type": "orml",
+                "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/LKSM.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x04000000",
-                    "currencyIdType": "turing_runtime.CurrencyId",
+                    "currencyIdType": "u32",
                     "existentialDeposit": "500000000",
                     "transfersEnabled": true
                 }
@@ -3715,11 +3715,11 @@
                 "assetId": 5,
                 "symbol": "HKO",
                 "precision": 12,
-                 "type": "orml",
+                "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/HKO.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x05000000",
-                    "currencyIdType": "turing_runtime.CurrencyId",
+                    "currencyIdType": "u32",
                     "existentialDeposit": "500000000000",
                     "transfersEnabled": true
                 }
@@ -3728,11 +3728,11 @@
                 "assetId": 6,
                 "symbol": "sKSM",
                 "precision": 12,
-                 "type": "orml",
+                "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/sKSM.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x06000000",
-                    "currencyIdType": "turing_runtime.CurrencyId",
+                    "currencyIdType": "u32",
                     "existentialDeposit": "500000000",
                     "transfersEnabled": true
                 }
@@ -3742,11 +3742,11 @@
                 "symbol": "PHA",
                 "precision": 12,
                 "priceId": "pha",
-                 "type": "orml",
+                "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/Phala.svg",
                 "typeExtras": {
                     "currencyIdScale": "0x07000000",
-                    "currencyIdType": "turing_runtime.CurrencyId",
+                    "currencyIdType": "u32",
                     "existentialDeposit": "10000000000",
                     "transfersEnabled": true
                 }


### PR DESCRIPTION
Turing network have changed their currencyIdType:

https://github.com/OAK-Foundation/OAK-blockchain/pull/266

TokenId:

https://github.com/OAK-Foundation/OAK-blockchain/blob/5830b71c7aacf487ef20502e14b77ecc7667717d/primitives/src/lib.rs#L53