### PR TITLE
Fix account address for Turing network

### DIFF
--- a/tests/chains_for_testBalance.json
+++ b/tests/chains_for_testBalance.json
@@ -182,7 +182,7 @@
     {
         "chainId": "0f62b701fb12d02237a33b84818c11f621653d2b1614c777973babf4652b535d",
         "name": "Turing",
-        "account": "0x488ced7d199b4386081a52505962128da5a3f54f4665db3d78b6e9f9e89eea4d"
+        "account": "0xde6c3184c7b03cf3d3623d079a033b007aab9e09f04ee8764490b254d596b57f"
     },
     {
         "chainId": "cdedc8eadbfa209d3f207bba541e57c3c58a667b05a2e1d1e86353c9000758da",


### PR DESCRIPTION
Test account was exhausted:
https://turing.subscan.io/account/67nmVh57G9yo7sqiGLjgNNqtUd7H2CSESTyQgp5272aMibwS

Change to an another one:
https://turing.subscan.io/account/6BBGxHoTygiPF3GYvuUoZU9tivMZwdmkNFuQk3JjfDmGpbVC