### PR TITLE
Update nodes list

### DIFF
--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -3727,10 +3727,6 @@
             {
                 "url": "wss://rpc.composable.finance",
                 "name": "Composable node"
-            },
-            {
-                "url": "wss://composable-rpc.dwellir.com",
-                "name": "Dwellir node"
             }
         ],
         "explorers": [

--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -2936,10 +2936,6 @@
             {
                 "url": "wss://rpc.kico.dico.io",
                 "name": "DICO FOUNDATION node"
-            },
-            {
-                "url": "wss://rpc.api.kico.dico.io",
-                "name": "DICO FOUNDATION 2 node"
             }
         ],
         "types": {

--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -108,7 +108,7 @@
                 "name": "Dwellir node"
             },
             {
-                "url": "wss://kusama.public.curie.radiumblock.co/ws",
+                "url": "wss://kusama.public.curie.radiumblock.xyz/ws",
                 "name": "Radium block node"
             }
         ],

--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -2887,10 +2887,6 @@
                 "name": "Dwellir node"
             },
             {
-                "url": "wss://rpc-0.zeitgeist.pm",
-                "name": "ZeitgeistPM node"
-            },
-            {
                 "url": "wss://zeitgeist.api.onfinality.io/public-ws",
                 "name": "OnFinality node"
             }

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -3143,10 +3143,6 @@
                 "name": "Dwellir node"
             },
             {
-                "url": "wss://rpc-0.zeitgeist.pm",
-                "name": "ZeitgeistPM node"
-            },
-            {
                 "url": "wss://zeitgeist.api.onfinality.io/public-ws",
                 "name": "OnFinality node"
             }

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -108,7 +108,7 @@
                 "name": "Dwellir node"
             },
             {
-                "url": "wss://kusama.public.curie.radiumblock.co/ws",
+                "url": "wss://kusama.public.curie.radiumblock.xyz/ws",
                 "name": "Radium block node"
             }
         ],

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -4014,10 +4014,6 @@
             {
                 "url": "wss://rpc.composable.finance",
                 "name": "Composable node"
-            },
-            {
-                "url": "wss://composable-rpc.dwellir.com",
-                "name": "Dwellir node"
             }
         ],
         "explorers": [

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -3196,10 +3196,6 @@
             {
                 "url": "wss://rpc.kico.dico.io",
                 "name": "DICO FOUNDATION node"
-            },
-            {
-                "url": "wss://rpc.api.kico.dico.io",
-                "name": "DICO FOUNDATION 2 node"
             }
         ],
         "types": {


### PR DESCRIPTION
Based on test results was found some deprecated nodes:

- [Composable](https://github.com/polkadot-js/apps/blob/140015da0be9c1fff00db72b5bbbbd9469a009fc/packages/apps-config/src/endpoints/productionRelayPolkadot.ts#L130) dwellir node is no longer available
- [KICO](https://github.com/polkadot-js/apps/blob/140015da0be9c1fff00db72b5bbbbd9469a009fc/packages/apps-config/src/endpoints/productionRelayKusama.ts#L233) second node is no longer available
- [Zeitgest](https://github.com/polkadot-js/apps/blob/140015da0be9c1fff00db72b5bbbbd9469a009fc/packages/apps-config/src/endpoints/productionRelayKusama.ts#L504) node is no longer available
- Radium node for [Kusama](https://github.com/polkadot-js/apps/blob/140015da0be9c1fff00db72b5bbbbd9469a009fc/packages/apps-config/src/endpoints/productionRelayKusama.ts#L544) was updated