### PR TITLE
Adding Tinkernet < TNKR > Basilisk

### DIFF
--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -4702,6 +4702,10 @@
             {
                 "url": "wss://tinker.invarch.network",
                 "name": "InvArch node"
+            },
+            {
+                "url": "wss://invarch-tinkernet.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
             }
         ],
         "types": {

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -3898,7 +3898,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "15740614557362"
+                    "value": "25678855576660"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -222,6 +222,20 @@
     "WND-Westmint": {
       "chainId": "67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9",
       "multiLocation": {}
+    },
+    "TNKR": {
+      "chainId": "d42e9606a995dfe433dc7955dc2a70f495f350f373daa200098ae84437816ad2",
+      "multiLocation": {
+        "parachainId": 2125,
+        "generalIndex": "0"
+      },
+      "reserveFee": {
+        "mode": {
+          "type": "proportional",
+          "value": "23175508123000"
+        },
+        "instructions": "xtokensReserve"
+      }
     }
   },
   "instructions": {
@@ -272,7 +286,8 @@
     "d611f22d291c5b7b69f1e105cca03352984c344c4421977efaa4cbdd1834e2aa": "150000000",
     "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755": "100000000",
     "e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e": "1000000000",
-    "67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9": "1000000000"
+    "67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9": "1000000000",
+    "d42e9606a995dfe433dc7955dc2a70f495f350f373daa200098ae84437816ad2": "100000000"
   },
   "chains": [
     {
@@ -3707,6 +3722,29 @@
               "type": "xtokens"
             }
           ]
+        },
+        {
+          "assetId": 3,
+          "assetLocation": "TNKR",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "d42e9606a995dfe433dc7955dc2a70f495f350f373daa200098ae84437816ad2",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "23175508123000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
         }
       ]
     },
@@ -3838,6 +3876,34 @@
                 }
               },
               "type": "xcmpallet"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "chainId": "d42e9606a995dfe433dc7955dc2a70f495f350f373daa200098ae84437816ad2",
+      "assets": [
+        {
+          "assetId": 0,
+          "assetLocation": "TNKR",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755",
+                "assetId": 3,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "15740614557362"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
             }
           ]
         }


### PR DESCRIPTION
This pull-request adds XCMs for TNKR token between Basilisk and Tinkernet.

Basilisk fee was calculated by [function](https://github.com/nova-wallet/support-utils/pull/9)

Tinkernet was calculated based on [code](https://github.com/InvArch/InvArch-Node/blob/main/runtime/tinkernet/src/lib.rs#L490):
<details>
  <summary>Calculation</summary>

```rust
pub const UNIT: Balance = 1_000_000_000_000;

fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
        let p = UNIT / 500;
        let q = Balance::from(ExtrinsicBaseWeight::get().ref_time());
        smallvec![WeightToFeeCoefficient {
            degree: 1,
            negative: false,
            coeff_frac: Perbill::from_rational(p % q, q),
            coeff_integer: p / q,
        }]
    }

(p / q) * UNIT

p = 1_000_000_000_000 / 500 = 2000000000
q = 86298000

p / q = 23,175508123

p / q * 1_000_000_000_000 = 23175508123000
```

</details>

Tested:
<details>
  <summary>Tinkernet   TNKR > Basilisk</summary>

Transfer amount = 1 TNKR
Fee coefficient was multiplied by 1.6 for the reason of price changing

Before:
<img width="200" alt="Screenshot 2022-10-18 at 19 21 49" src="https://user-images.githubusercontent.com/40560660/196458241-2014e1a9-d350-45a6-a7c5-debcf61b1e19.png">

After:
<img width="200" alt="Screenshot 2022-10-18 at 19 22 34" src="https://user-images.githubusercontent.com/40560660/196458325-2ff56d55-0a92-4bc9-88e8-6c4b52c211c2.png">

</details>


<details>
  <summary>Tinkernet < TNKR Basilisk</summary>

Transfer Amount = 0.1 TNKR
Before:
<img width="200" alt="Screenshot 2022-10-18 at 19 16 23" src="https://user-images.githubusercontent.com/40560660/196458898-8961ec46-c050-4533-b06d-05cb561bc40e.png">

After:
<img width="200" alt="Screenshot 2022-10-18 at 19 16 31" src="https://user-images.githubusercontent.com/40560660/196459032-fa291f15-7706-4456-8cc1-71ca73d6d333.png">

</details>

Also it is added additional Tinkernet node, as first one is not available