### PR TITLE
remove dwellir Parallel node

### DIFF
--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -2987,10 +2987,6 @@
             {
                 "url": "wss://parallel.api.onfinality.io/public-ws",
                 "name": "OnFinality node"
-            },
-            {
-                "url": "wss://parallel-rpc.dwellir.com",
-                "name": "Dwellir node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
Dwellir node for the Parallel network is not available anymore.