### PR TITLE
Fix RuntimeDispatchInfo for Polkadot

### DIFF
--- a/chains/v2/types/polkadot.json
+++ b/chains/v2/types/polkadot.json
@@ -16,11 +16,11 @@
         "type_mapping": [
           [
             "weight",
-            "frame_support.weights.weight_v2.Weight"
+            "sp_weights.weight_v2.Weight"
           ],
           [
             "class",
-            "frame_support.weights.DispatchClass"
+            "frame_support.dispatch.DispatchClass"
           ],
           [
             "partialFee",


### PR DESCRIPTION
- switch RuntimeDispatchInfo weights for v2

<img width="512" alt="weights" src="https://user-images.githubusercontent.com/570634/201324622-b229700d-3be5-41db-8913-6a743127160a.png">

<img width="512" alt="class" src="https://user-images.githubusercontent.com/570634/201324763-a4736bee-2015-4ed7-9954-2f434a720c58.png">
