### PR TITLE
Remove Dwellir nodes for Darwinia

### DIFF
--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -3074,10 +3074,6 @@
             {
                 "url": "wss://crab-parachain-rpc.darwinia.network/",
                 "name": "Crab node"
-            },
-            {
-                "url": "wss://darwiniacrab-rpc.dwellir.com",
-                "name": "Dwellir node"
             }
         ],
         "explorers": [

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -3420,10 +3420,6 @@
             {
                 "url": "wss://crab-parachain-rpc.darwinia.network/",
                 "name": "Crab node"
-            },
-            {
-                "url": "wss://darwiniacrab-rpc.dwellir.com",
-                "name": "Dwellir node"
             }
         ],
         "explorers": [


### PR DESCRIPTION
Dwellir nodes for Darwinia now lead to the Solochain network.

<img width="600" alt="Screenshot 2022-11-13 at 13 36 38" src="https://user-images.githubusercontent.com/40560660/201513201-25a8f027-49af-4315-94de-44e156f6636b.png">


<img width="600" alt="Screenshot 2022-11-13 at 13 36 58" src="https://user-images.githubusercontent.com/40560660/201513195-504d2e72-d5f3-45aa-bfd0-cda9d645b12d.png">

