### PR TITLE
Replace CrustShadow node by new one

### DIFF
--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -3153,7 +3153,7 @@
         ],
         "nodes": [
             {
-                "url": "wss://rpc2-shadow.crust.network/",
+                "url": "wss://rpc-sha-subscan.crust.network",
                 "name": "Crust node"
             },
             {

--- a/chains/v5/chains_dev.json
+++ b/chains/v5/chains_dev.json
@@ -3499,7 +3499,7 @@
         ],
         "nodes": [
             {
-                "url": "wss://rpc2-shadow.crust.network/",
+                "url": "wss://rpc-sha-subscan.crust.network",
                 "name": "Crust node"
             },
             {


### PR DESCRIPTION
Node address was updated for CrustShadow network

<img width="846" alt="Screenshot 2022-11-15 at 14 12 04" src="https://user-images.githubusercontent.com/40560660/201878602-4e0c38cc-3d0a-428c-aa5b-3f06d913b664.png">
