### PR TITLE
Change fee type for GLMR

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -99,7 +99,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "50000000000000000000"
+          "value": "5000000000000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -3108,7 +3108,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "50000000000000000000"
+                    "value": "5000000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3969,7 +3969,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "50000000000000000000"
+                    "value": "5000000000000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -3983,7 +3983,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "50000000000000000000"
+                    "value": "5000000000000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -4052,7 +4052,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "50000000000000000000"
+                    "value": "5000000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -99,7 +99,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "50000000000000000"
+          "value": "50000000000000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -3108,7 +3108,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "50000000000000000"
+                    "value": "50000000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3969,7 +3969,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "50000000000000000"
+                    "value": "50000000000000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -3983,7 +3983,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "50000000000000000"
+                    "value": "50000000000000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -4052,7 +4052,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "50000000000000000"
+                    "value": "50000000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -99,7 +99,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "5000000000000000000"
+          "value": "5000001147000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -3108,7 +3108,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "5000000000000000000"
+                    "value": "5000001147000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3969,7 +3969,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "5000000000000000000"
+                    "value": "5000001147000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -3983,7 +3983,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "5000000000000000000"
+                    "value": "5000001147000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -4052,7 +4052,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "5000000000000000000"
+                    "value": "5000001147000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -99,7 +99,7 @@
       "reserveFee": {
         "mode": {
           "type": "proportional",
-          "value": "5000001147000000000"
+          "value": "5000001148000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -3108,7 +3108,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "5000001147000000000"
+                    "value": "5000001148000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3969,7 +3969,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "5000001147000000000"
+                    "value": "5000001148000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -3983,7 +3983,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "5000001147000000000"
+                    "value": "5000001148000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -4052,7 +4052,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "5000001147000000000"
+                    "value": "5000001148000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -98,7 +98,8 @@
       },
       "reserveFee": {
         "mode": {
-          "type": "standard"
+          "type": "proportional",
+          "value": "50000000000000000"
         },
         "instructions": "xtokensReserve"
       }
@@ -3106,7 +3107,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "50000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3966,7 +3968,8 @@
                 "assetId": 1,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "50000000000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -3979,7 +3982,8 @@
                 "assetId": 1,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "50000000000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -4047,7 +4051,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "50000000000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
It was approximately calculated based on pallet source and actual transaction fee from SubScan.

Example:
https://bifrost.subscan.io/extrinsic/1147259-1?event=1147259-3