### PR TITLE
Adding gov-v1 for the Kusama network

### DIFF
--- a/chains/v5/chains.json
+++ b/chains/v5/chains.json
@@ -165,7 +165,8 @@
         },
         "options": [
             "crowdloans",
-            "governance"
+            "governance",
+            "governance-v1"
         ]
     },
     {

--- a/chains/v6/chains.json
+++ b/chains/v6/chains.json
@@ -169,7 +169,8 @@
         },
         "options": [
             "crowdloans",
-            "governance"
+            "governance",
+            "governance-v1"
         ]
     },
     {


### PR DESCRIPTION
This PR adds governance-v1 as option for the Kusama network