### PR TITLE
Remove deprecated Subsocial DApp

### DIFF
--- a/dapps/dapps.json
+++ b/dapps/dapps.json
@@ -74,14 +74,6 @@
       ]
     },
     {
-      "name": "Subsocial App",
-      "url": "https://app.subsocial.network/",
-      "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/color/Subsocial.png",
-      "categories": [
-        "community"
-      ]
-    },
-    {
       "name": "PolkaVerse",
       "url": "https://polkaverse.com/",
       "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/dapps/color/PolkaVerse.svg",

--- a/dapps/dapps.json
+++ b/dapps/dapps.json
@@ -74,6 +74,14 @@
       ]
     },
     {
+      "name": "Subsocial App",
+      "url": "https://app.subsocial.network/",
+      "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/color/Subsocial.png",
+      "categories": [
+        "community"
+      ]
+    },
+    {
       "name": "PolkaVerse",
       "url": "https://polkaverse.com/",
       "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/dapps/color/PolkaVerse.svg",

--- a/dapps/dapps_dev.json
+++ b/dapps/dapps_dev.json
@@ -78,14 +78,6 @@
       ]
     },
     {
-      "name": "Subsocial App",
-      "url": "https://app.subsocial.network/",
-      "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/color/Subsocial.png",
-      "categories": [
-        "community"
-      ]
-    },
-    {
       "name": "PolkaVerse",
       "url": "https://polkaverse.com/",
       "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/dapps/color/PolkaVerse.svg",


### PR DESCRIPTION
The SubSocial DApp has changed its branding. In the case was added separate DApp by that [PR](https://github.com/nova-wallet/nova-utils/pull/1026)
This PR removes the old one