### PR TITLE
Adding subquery for DAO-IPCI,Amplitude,XX-network

### DIFF
--- a/chains/v6/chains_dev.json
+++ b/chains/v6/chains_dev.json
@@ -5169,6 +5169,12 @@
             }
         ],
         "externalApi": {
+            "history": [
+                {
+                    "type": "subquery",
+                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-amplitude"
+                }
+            ],
             "governance": {
                 "type": "polkassembly",
                 "url": "https://polkassembly-hasura.herokuapp.com/v1/graphql"
@@ -5591,6 +5597,14 @@
                 "name": "Airalab node"
             }
         ],
+        "externalApi": {
+            "history": [
+                {
+                    "type": "subquery",
+                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-dao-ipci"
+                }
+            ]
+        },
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/dao_ipci.json",
             "overridesCommon": true
@@ -5735,6 +5749,14 @@
                 "event": null
             }
         ],
+        "externalApi": {
+            "history": [
+                {
+                    "type": "subquery",
+                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-xx-network"
+                }
+            ]
+        },
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/xx_network.json",
             "overridesCommon": true

--- a/chains/v7/chains_dev.json
+++ b/chains/v7/chains_dev.json
@@ -5220,6 +5220,12 @@
             }
         ],
         "externalApi": {
+            "history": [
+                {
+                    "type": "subquery",
+                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-amplitude"
+                }
+            ],
             "governance": {
                 "type": "polkassembly",
                 "url": "https://polkassembly-hasura.herokuapp.com/v1/graphql",
@@ -5648,6 +5654,14 @@
                 "name": "Airalab node"
             }
         ],
+        "externalApi": {
+            "history": [
+                {
+                    "type": "subquery",
+                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-dao-ipci"
+                }
+            ]
+        },
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/dao_ipci.json",
             "overridesCommon": true
@@ -5792,6 +5806,14 @@
                 "event": null
             }
         ],
+        "externalApi": {
+            "history": [
+                {
+                    "type": "subquery",
+                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-xx-network"
+                }
+            ]
+        },
         "types": {
             "url": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/chains/v2/types/xx_network.json",
             "overridesCommon": true


### PR DESCRIPTION
Was run new subquery projects:

- [XX](https://project.subquery.network/orgs/nova-wallet/projects/nova-wallet-xx-network/deployments)
- [Amplitude](https://project.subquery.network/orgs/nova-wallet/projects/nova-wallet-amplitude/deployments)
- [DAO-IPCI](https://project.subquery.network/orgs/nova-wallet/projects/nova-wallet-dao-ipci/deployments)

PR in subquery project:
https://github.com/nova-wallet/subquery-nova/pull/189