### PR TITLE
HydraDX XCM transfers to PROD

### DIFF
--- a/chains/v6/chains.json
+++ b/chains/v6/chains.json
@@ -2528,20 +2528,6 @@
                     "existentialDeposit": "100",
                     "transfersEnabled": true
                 }
-            },
-            {
-                "assetId": 13,
-                "symbol": "DAI",
-                "precision": 18,
-                "type": "orml",
-                "priceId": "dai",
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
-                "typeExtras": {
-                    "currencyIdScale": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae",
-                    "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "10000000000000000",
-                    "transfersEnabled": true
-                }
             }
         ],
         "nodes": [

--- a/chains/v6/chains.json
+++ b/chains/v6/chains.json
@@ -2528,6 +2528,20 @@
                     "existentialDeposit": "100",
                     "transfersEnabled": true
                 }
+            },
+            {
+                "assetId": 13,
+                "symbol": "DAI",
+                "precision": 18,
+                "type": "orml",
+                "priceId": "dai",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "10000000000000000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [
@@ -3809,6 +3823,34 @@
                 "symbol": "HDX",
                 "precision": 12,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/HydraDX.svg"
+            },
+            {
+                "assetId": 1,
+                "symbol": "DOT",
+                "precision": 10,
+                "priceId": "polkadot",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Polkadot.svg",
+                "type": "orml",
+                "typeExtras": {
+                    "currencyIdScale": "0x05000000",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "17540000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 2,
+                "symbol": "DAI",
+                "precision": 18,
+                "priceId": "dai",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x02000000",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "10000000000000000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [

--- a/chains/v7/chains.json
+++ b/chains/v7/chains.json
@@ -2545,20 +2545,6 @@
                     "existentialDeposit": "100",
                     "transfersEnabled": true
                 }
-            },
-            {
-                "assetId": 13,
-                "symbol": "DAI",
-                "precision": 18,
-                "type": "orml",
-                "priceId": "dai",
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
-                "typeExtras": {
-                    "currencyIdScale": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae",
-                    "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "10000000000000000",
-                    "transfersEnabled": true
-                }
             }
         ],
         "nodes": [

--- a/chains/v7/chains.json
+++ b/chains/v7/chains.json
@@ -2545,6 +2545,20 @@
                     "existentialDeposit": "100",
                     "transfersEnabled": true
                 }
+            },
+            {
+                "assetId": 13,
+                "symbol": "DAI",
+                "precision": 18,
+                "type": "orml",
+                "priceId": "dai",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "10000000000000000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [
@@ -3836,6 +3850,34 @@
                 "symbol": "HDX",
                 "precision": 12,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/HydraDX.svg"
+            },
+            {
+                "assetId": 1,
+                "symbol": "DOT",
+                "precision": 10,
+                "priceId": "polkadot",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Polkadot.svg",
+                "type": "orml",
+                "typeExtras": {
+                    "currencyIdScale": "0x05000000",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "17540000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 2,
+                "symbol": "DAI",
+                "precision": 18,
+                "priceId": "dai",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x02000000",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "10000000000000000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [

--- a/chains/v8/chains.json
+++ b/chains/v8/chains.json
@@ -2558,6 +2558,20 @@
                     "existentialDeposit": "100",
                     "transfersEnabled": true
                 }
+            },
+            {
+                "assetId": 13,
+                "symbol": "DAI",
+                "precision": 18,
+                "type": "orml",
+                "priceId": "dai",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae",
+                    "currencyIdType": "acala_primitives.currency.CurrencyId",
+                    "existentialDeposit": "10000000000000000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [
@@ -3841,6 +3855,34 @@
                 "symbol": "HDX",
                 "precision": 12,
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/HydraDX.svg"
+            },
+            {
+                "assetId": 1,
+                "symbol": "DOT",
+                "precision": 10,
+                "priceId": "polkadot",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Polkadot.svg",
+                "type": "orml",
+                "typeExtras": {
+                    "currencyIdScale": "0x05000000",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "17540000",
+                    "transfersEnabled": true
+                }
+            },
+            {
+                "assetId": 2,
+                "symbol": "DAI",
+                "precision": 18,
+                "priceId": "dai",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x02000000",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "10000000000000000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [

--- a/chains/v8/chains.json
+++ b/chains/v8/chains.json
@@ -2558,20 +2558,6 @@
                     "existentialDeposit": "100",
                     "transfersEnabled": true
                 }
-            },
-            {
-                "assetId": 13,
-                "symbol": "DAI",
-                "precision": 18,
-                "type": "orml",
-                "priceId": "dai",
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/DAI.svg",
-                "typeExtras": {
-                    "currencyIdScale": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae",
-                    "currencyIdType": "acala_primitives.currency.CurrencyId",
-                    "existentialDeposit": "10000000000000000",
-                    "transfersEnabled": true
-                }
             }
         ],
         "nodes": [

--- a/xcm/v2/transfers.json
+++ b/xcm/v2/transfers.json
@@ -268,7 +268,8 @@
     "d611f22d291c5b7b69f1e105cca03352984c344c4421977efaa4cbdd1834e2aa": "150000000",
     "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755": "100000000",
     "d42e9606a995dfe433dc7955dc2a70f495f350f373daa200098ae84437816ad2": "100000000",
-    "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b": "200000000"
+    "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b": "200000000",
+    "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d": "100000000"
   },
   "chains": [
     {
@@ -1377,6 +1378,20 @@
                 }
               },
               "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "46842105263158"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
             }
           ]
         },
@@ -1665,6 +1680,20 @@
                 }
               },
               "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "46842105263158"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
             }
           ]
         }
@@ -1897,6 +1926,20 @@
                   "mode": {
                     "type": "proportional",
                     "value": "11587000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "46842105263158"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3133,6 +3176,20 @@
                 }
               },
               "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "46842105263158"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
             }
           ]
         },
@@ -3490,6 +3547,20 @@
                   "mode": {
                     "type": "proportional",
                     "value": "11587000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "46842105263158"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3937,6 +4008,132 @@
                   "mode": {
                     "type": "proportional",
                     "value": "33068783068"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "46842105263158"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "chainId": "afdc188f45c71dacbaa0b62e16a91f726c7b8699a9748cdf715459de6b7f366d",
+      "assets": [
+        {
+          "assetId": 1,
+          "assetLocation": "DOT",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
+                "assetId": 0,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "117354363236"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "fc41b9bd8ef8fe53d58c7ea67c794c7ec9a73daf05e6d54b14ff6342c99ba64c",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "3314035960"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "9eb76c5184c4ab8679d2d5d819fdf90b9c001403e9e17da2e14b6d8aec4029c6",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "1000000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b",
+                "assetId": 2,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "11587000000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "bf88efe70e9e0e916416e8bed61f2b45717f517d7f3523e33c7b001e5ffcbc72",
+                "assetId": 2,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "20306692567"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "fe58ea77779b7abda7da4ec526d14db9b1e9cd40a217c34892af80a9b332b76d",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "33068783068"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            },
+            {
+              "destination": {
+                "chainId": "e61a41c53f5dcd0beb09df93b34402aada44cb05117b71059cce40a2723a4e97",
+                "assetId": 1,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "53711462025"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers.json
+++ b/xcm/v2/transfers.json
@@ -1386,7 +1386,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1688,7 +1688,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -1939,7 +1939,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3184,7 +3184,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3560,7 +3560,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -4021,7 +4021,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xtokensDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -1511,7 +1511,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -1813,7 +1813,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xcmPalletDest"
                 }
@@ -2064,7 +2064,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3461,7 +3461,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -3837,7 +3837,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xtokensDest"
                 }
@@ -4352,7 +4352,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "46842105263158"
+                    "value": "30000000000"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
This PR is:

- adding new tokens:
`DAI` in **HydraDX**
`DOT` in **HydraDX**
- adding XCMs for `DOT` in HydraDX

**Note:**
as for HydraDX is used dynamic fee based on pools ratio for the coefficient was taken average fee price and multiplied on 2.
example: https://hydradx.subscan.io/xcm_message/polkadot-b7d0ca3cd772761d1b3c116f8758b0bb8c286fa3