### PR TITLE
Fix types for Moonriver

### DIFF
--- a/chains/v2/types/moonriver.json
+++ b/chains/v2/types/moonriver.json
@@ -26,8 +26,8 @@
     },
     "ExtrinsicSignature": "EthereumSignature",
     "ParaId": "polkadot_parachain.primitives.Id",
-    "moonriver_runtime.Event": "GenericEvent",
-    "moonriver_runtime.Call": "GenericCall",
+    "moonriver_runtime.RuntimeEvent": "GenericEvent",
+    "moonriver_runtime.RuntimeCall": "GenericCall",
     "sp_core.crypto.AccountId32": "GenericAccountId",
     "pallet_identity.types.Data": "Data"
   },

--- a/chains/v2/types/moonriver.json
+++ b/chains/v2/types/moonriver.json
@@ -1,5 +1,5 @@
 {
-  "runtime_id": 900,
+  "runtime_id": 2000,
   "types": {
     "Balance": "u128",
     "Index": "u32",


### PR DESCRIPTION
- rename Event to RuntimeEvent and Call to RuntimeCall

<img width="1642" alt="fix-types" src="https://user-images.githubusercontent.com/570634/211745502-28868d7b-d069-4d70-bd7e-3a2b6df97be9.png">

<img width="1655" alt="image" src="https://user-images.githubusercontent.com/570634/211746146-d49750eb-5e5c-4f0f-be02-5d87ca0b947a.png">

