### PR TITLE
Edgeware WSS correction

### DIFF
--- a/chains/v2/chains.json
+++ b/chains/v2/chains.json
@@ -1199,7 +1199,7 @@
         ],
         "nodes": [
             {
-                "url": "wss://mainnet.edgewa.re",
+                "url": "wss://mainnet2.edgewa.re",
                 "name": "Commonwealth Labs"
             },
             {


### PR DESCRIPTION
Edgeware Mainnet is not fetching fees in Nova Wallet .