### PR TITLE
Edgeware WSS Correction

### DIFF
--- a/chains/v2/chains_dev.json
+++ b/chains/v2/chains_dev.json
@@ -1206,7 +1206,7 @@
         ],
         "nodes": [
             {
-                "url": "wss://mainnet.edgewa.re",
+                "url": "wss://mainnet2.edgewa.re",
                 "name": "Commonwealth Labs"
             },
             {


### PR DESCRIPTION
Edgeware Mainnet is not fetching fees in Nova Wallet .