### PR TITLE
fix python version to run xcm script

### DIFF
--- a/.github/workflows/update_network_list.yaml
+++ b/.github/workflows/update_network_list.yaml
@@ -149,6 +149,10 @@ jobs:
       - name: Set up actual paths
         uses: ./.github/workflows/setup-path
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9.15'
+
       - name: Install dependencies
         run: |
           cd ../support


### PR DESCRIPTION
This PR fixes this problem:
https://github.com/nova-wallet/nova-utils/actions/runs/4171288103/jobs/7221076071