### PR TITLE
Promote USDT for Basilisk

### DIFF
--- a/chains/v7/chains.json
+++ b/chains/v7/chains.json
@@ -1674,6 +1674,20 @@
                     "existentialDeposit": "1000000000",
                     "transfersEnabled": true
                 }
+            },
+            {
+                "assetId": 4,
+                "symbol": "USDT",
+                "precision": 6,
+                "type": "orml",
+                "priceId": "tether",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0e000000",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "10000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [

--- a/chains/v8/chains.json
+++ b/chains/v8/chains.json
@@ -1702,6 +1702,20 @@
                     "existentialDeposit": "1000000000",
                     "transfersEnabled": true
                 }
+            },
+            {
+                "assetId": 4,
+                "symbol": "USDT",
+                "precision": 6,
+                "type": "orml",
+                "priceId": "tether",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0e000000",
+                    "currencyIdType": "u32",
+                    "existentialDeposit": "10000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [

--- a/xcm/v2/transfers.json
+++ b/xcm/v2/transfers.json
@@ -2069,6 +2069,20 @@
                 }
               },
               "type": "xcmpallet"
+            },
+            {
+              "destination": {
+                "chainId": "a85cfb9b9fd4d622a5b28289a02347af987d8f73fa3108450e2b4a11c1ce5755",
+                "assetId": 4,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "7175208"
+                  },
+                  "instructions": "xcmPalletDest"
+                }
+              },
+              "type": "xcmpallet"
             }
           ]
         }
@@ -3803,6 +3817,29 @@
                   "mode": {
                     "type": "proportional",
                     "value": "23175508123000"
+                  },
+                  "instructions": "xtokensDest"
+                }
+              },
+              "type": "xtokens"
+            }
+          ]
+        },
+        {
+          "assetId": 4,
+          "assetLocation": "USDT",
+          "assetLocationPath": {
+            "type": "absolute"
+          },
+          "xcmTransfers": [
+            {
+              "destination": {
+                "chainId": "48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a",
+                "assetId": 7,
+                "fee": {
+                  "mode": {
+                    "type": "proportional",
+                    "value": "341500"
                   },
                   "instructions": "xtokensDest"
                 }


### PR DESCRIPTION
This PR will add:
- USDT asset for Basilisk
- XCM transfer Statemine < USDT > Basilisk

<details>
  <summary>Asset proofs</summary>

<img width="300" alt="Screenshot 2023-02-14 at 09 26 31" src="https://user-images.githubusercontent.com/40560660/218668922-f493a52a-8ae6-402e-a5d7-05222ad5f3d2.png">

<img width="300" alt="Screenshot 2023-02-14 at 09 26 47" src="https://user-images.githubusercontent.com/40560660/218668940-617bafde-8eaf-43d9-b2d1-85a5c1380c44.png">

<img width="300" alt="Screenshot 2023-02-14 at 09 26 58" src="https://user-images.githubusercontent.com/40560660/218668950-15075545-0674-463f-9eda-40a63ef18b29.png">


</details>


<details>
  <summary>XCM proofs</summary>

[Statemine -> Basilisk](https://basilisk.subscan.io/xcm_message/kusama-a5709ecd6240151fe3d21fe9620c48fbb4a45ad1)

[Statemine <- Basilisk](https://basilisk.subscan.io/xcm_message/kusama-f309f51ec7e019c5f4ad165147014580a5ec4cbf)

<img width="300" alt="Screenshot 2023-02-14 at 10 27 23" src="https://user-images.githubusercontent.com/40560660/218669003-c3088686-7f07-4b57-b48b-01eba0c69cf4.png">

<img width="300" alt="Screenshot 2023-02-14 at 10 28 53" src="https://user-images.githubusercontent.com/40560660/218669021-d07e744e-8c61-4a4a-94b8-14e5c8c8e971.png">


</details>