### PR TITLE
Promote update for nodes

### DIFF
--- a/chains/v7/chains.json
+++ b/chains/v7/chains.json
@@ -24,12 +24,20 @@
                 "name": "OnFinality node"
             },
             {
-                "url": "wss://polkadot-rpc.dwellir.com",
-                "name": "Dwellir node"
-            },
-            {
                 "url": "wss://rpc.polkadot.io",
                 "name": "Parity node"
+            },
+            {
+                "url": "wss://rpc.dotters.network/polkadot",
+                "name": "Dotters Net node"
+            },
+            {
+                "url": "wss://rpc.ibp.network/polkadot",
+                "name": "IBP network node"
+            },
+            {
+                "url": "wss://polkadot-rpc.dwellir.com",
+                "name": "Dwellir node"
             },
             {
                 "url": "wss://1rpc.io/dot",
@@ -111,8 +119,20 @@
         ],
         "nodes": [
             {
+                "url": "wss://rpc.ibp.network/kusama",
+                "name": "IBP network node"
+            },
+            {
+                "url": "wss://1rpc.io/ksm",
+                "name": "Automata 1RPC node"
+            },
+            {
                 "url": "wss://kusama-rpc.dwellir.com",
                 "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc.dotters.network/kusama",
+                "name": "Dotters Net node"
             },
             {
                 "url": "wss://kusama.public.curie.radiumblock.co/ws",
@@ -1911,10 +1931,6 @@
             {
                 "url": "wss://heiko-rpc.parallel.fi",
                 "name": "Parallel"
-            },
-            {
-                "url": "wss://heiko-rpc.dwellir.com",
-                "name": "Dwellir node"
             }
         ],
         "types": {
@@ -3407,8 +3423,8 @@
                 "name": "Composable node"
             },
             {
-                "url": "wss://picasso-rpc.dwellir.com",
-                "name": "Dwellir node"
+                "url": "wss://rpc.composablenodes.tech",
+                "name": "Composable node"
             }
         ],
         "explorers": [
@@ -5057,8 +5073,12 @@
                 "name": "AjunaNetwork node"
             },
             {
-                "url": "wss://bajun-rpc.dwellir.com",
-                "name": "Dwellir node"
+                "url": "wss://bajun.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://bajun.public.curie.radiumblock.co/ws",
+                "name": "Radium node"
             }
         ],
         "explorers": [
@@ -5207,8 +5227,8 @@
                 "name": "bLd node"
             },
             {
-                "url": "wss://ws-node-gm.terrabiodao.org",
-                "name": "TerraBioDao node"
+                "url": "wss://intern.gmordie.com",
+                "name": "GM intern node"
             },
             {
                 "url": "wss://leemo.gmordie.com",
@@ -5606,7 +5626,11 @@
         ],
         "nodes": [
             {
-                "url": "wss://rpc.xx.network",
+                "url": "wss://rpc-hetzner.xx.network",
+                "name": "xx Foundation node"
+            },
+            {
+                "url": "wss://rpc-do.xx.network",
                 "name": "xx Foundation node"
             },
             {

--- a/chains/v8/chains.json
+++ b/chains/v8/chains.json
@@ -24,12 +24,20 @@
                 "name": "OnFinality node"
             },
             {
-                "url": "wss://polkadot-rpc.dwellir.com",
-                "name": "Dwellir node"
-            },
-            {
                 "url": "wss://rpc.polkadot.io",
                 "name": "Parity node"
+            },
+            {
+                "url": "wss://rpc.dotters.network/polkadot",
+                "name": "Dotters Net node"
+            },
+            {
+                "url": "wss://rpc.ibp.network/polkadot",
+                "name": "IBP network node"
+            },
+            {
+                "url": "wss://polkadot-rpc.dwellir.com",
+                "name": "Dwellir node"
             },
             {
                 "url": "wss://1rpc.io/dot",
@@ -117,8 +125,20 @@
         ],
         "nodes": [
             {
+                "url": "wss://rpc.ibp.network/kusama",
+                "name": "IBP network node"
+            },
+            {
+                "url": "wss://1rpc.io/ksm",
+                "name": "Automata 1RPC node"
+            },
+            {
                 "url": "wss://kusama-rpc.dwellir.com",
                 "name": "Dwellir node"
+            },
+            {
+                "url": "wss://rpc.dotters.network/kusama",
+                "name": "Dotters Net node"
             },
             {
                 "url": "wss://kusama.public.curie.radiumblock.co/ws",
@@ -1941,14 +1961,6 @@
             {
                 "url": "wss://heiko-rpc.parallel.fi",
                 "name": "Parallel"
-            },
-            {
-                "url": "wss://parallel-heiko.api.onfinality.io/public-ws",
-                "name": "OnFinality node"
-            },
-            {
-                "url": "wss://heiko-rpc.dwellir.com",
-                "name": "Dwellir node"
             }
         ],
         "types": {
@@ -3443,8 +3455,8 @@
                 "name": "Composable node"
             },
             {
-                "url": "wss://picasso-rpc.dwellir.com",
-                "name": "Dwellir node"
+                "url": "wss://rpc.composablenodes.tech",
+                "name": "Composable node"
             }
         ],
         "explorers": [
@@ -5103,8 +5115,12 @@
                 "name": "AjunaNetwork node"
             },
             {
-                "url": "wss://bajun-rpc.dwellir.com",
-                "name": "Dwellir node"
+                "url": "wss://bajun.api.onfinality.io/public-ws",
+                "name": "OnFinality node"
+            },
+            {
+                "url": "wss://bajun.public.curie.radiumblock.co/ws",
+                "name": "Radium node"
             }
         ],
         "explorers": [
@@ -5253,8 +5269,8 @@
                 "name": "bLd node"
             },
             {
-                "url": "wss://ws-node-gm.terrabiodao.org",
-                "name": "TerraBioDao node"
+                "url": "wss://intern.gmordie.com",
+                "name": "GM intern node"
             },
             {
                 "url": "wss://leemo.gmordie.com",
@@ -5654,7 +5670,11 @@
         ],
         "nodes": [
             {
-                "url": "wss://rpc.xx.network",
+                "url": "wss://rpc-hetzner.xx.network",
+                "name": "xx Foundation node"
+            },
+            {
+                "url": "wss://rpc-do.xx.network",
                 "name": "xx Foundation node"
             },
             {


### PR DESCRIPTION
It is promotion of this changes:
https://github.com/nova-wallet/nova-utils/pull/1332

> This PR updates nodes for some network.
> 
>  It based on results of availability check:
> https://nova-wallet.github.io/test-runner/2550/#suites/9d18f59d45e37d7df438eba463d911c5/7aa121611606edda/
> 
> Also, the node order for Kusama and Polkadot was changed, based on data received by measure of getting base parameters:
> https://github.com/nova-wallet/nova-utils/blob/master/tests/test_can_query_base_parameters.py
> 
> Polkadot:
> <img width="540" alt="Screenshot 2023-02-28 at 19 34 36" src="https://user-images.githubusercontent.com/40560660/221920529-d08d5034-e1a2-4048-bded-eb41b3e1188c.png">
> 
> Kusama:
> <img width="550" alt="Screenshot 2023-02-28 at 19 38 51" src="https://user-images.githubusercontent.com/40560660/221920569-40f855d7-550a-432b-bc5d-5264b04a3608.png">
> 