### PR TITLE
Switch gov project to second

### DIFF
--- a/chains/v8/chains_dev.json
+++ b/chains/v8/chains_dev.json
@@ -210,7 +210,7 @@
             "governance-delegations": [
                 {
                     "type": "subquery",
-                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kusama-governance"
+                    "url": "https://api.subquery.network/sq/nova-wallet/nova-wallet-kusama-governance2"
                 }
             ]
         },


### PR DESCRIPTION
This PR is switching SubQuery governance project to second one:

https://managedservice.subquery.network/orgs/nova-wallet/projects/nova-wallet-kusama-governance2/deployments