### PR TITLE
Change fee for WND from standard to proportional

### DIFF
--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -220,7 +220,8 @@
       "multiLocation": {},
       "reserveFee": {
         "mode": {
-          "type": "standard"
+          "type": "proportional",
+          "value": "10543518372081"
         },
         "instructions": "xtokensReserve"
       }
@@ -4173,7 +4174,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "1054351837209"
                   },
                   "instructions": "xcmPalletTeleportDest"
                 }
@@ -4200,7 +4202,8 @@
                 "assetId": 0,
                 "fee": {
                   "mode": {
-                    "type": "standard"
+                    "type": "proportional",
+                    "value": "10543518372081"
                   },
                   "instructions": "xcmPalletTeleportDest"
                 }

--- a/xcm/v2/transfers_dev.json
+++ b/xcm/v2/transfers_dev.json
@@ -4175,7 +4175,7 @@
                 "fee": {
                   "mode": {
                     "type": "proportional",
-                    "value": "1054351837209"
+                    "value": "800000000000"
                   },
                   "instructions": "xcmPalletTeleportDest"
                 }


### PR DESCRIPTION
Fee was calculated based on polynomial functions:

Westend
https://github.com/paritytech/polkadot/blob/v0.9.39/runtime/westend/constants/src/lib.rs#L85

```python
UNITS = 1_000_000_000_000
CENTS = UNITS / 100
p = CENTS
q = 10 * 94_845_000
units_per_second = p / q * UNITS

print(units_per_second)

>> 10543518372080.764
```

Westmint
https://github.com/paritytech/cumulus/blob/parachains-v9370/parachains/runtimes/assets/westmint/src/constants.rs#L58

```python
UNITS = 1_000_000_000_000
CENTS = UNITS / 100
p = CENTS
q = 100 * 125_000_000
units_per_second = p / q * UNITS

print(units_per_second)

>> 800000000000
```