### PR TITLE
fix for XCM PRs

### DIFF
--- a/.github/workflows/make-pull-request/action.yml
+++ b/.github/workflows/make-pull-request/action.yml
@@ -19,6 +19,10 @@ inputs:
   pr-body:
     description: 'Body for creating Pull Request'
     required: true
+  pr-reviewer:
+    description: 'Reviewers for creating PR, support comma delimiter'
+    required: false
+    default: "stepanLav,leohar"
 
 runs:
   using: "composite"
@@ -49,6 +53,6 @@ runs:
           destination_branch: "master"
           pr_title: ${{ inputs.pr-title }}
           pr_body: ${{ inputs.pr-body }}
-          pr_reviewer: "stepanLav,leohar"
+          pr_reviewer: ${{ inputs.pr-reviewer }}
           pr_draft: false
           github_token: ${{ inputs.github-token }}

--- a/.github/workflows/update_xcm_data.yaml
+++ b/.github/workflows/update_xcm_data.yaml
@@ -69,6 +69,7 @@ jobs:
           commit-files: ${{ env.COMMIT_FILE }}
           commit-message: Update xcm coefficients
           github-token: ${{ secrets.PAT_TOKEN  }}
+          pr-reviewer: ${{ if eq(env.ENVIRONMENT, 'DEV') }}leohar${{ else }}ERussel,leohar,valentunn${{ endif }}
           branch-name: update-xcm-coefficients-${{github.run_number}}
           pr-title: 🆙 Update XCM coefficients for ${{ env.ENVIRONMENT }} env
           pr-body: This PR was generated automatically 🤖


### PR DESCRIPTION
This PR fixes problem with failed actions, when it try to assign creator as reviewer.
Also, it changes DEV\PROD reviewers lineup