### PR TITLE
Change ss58 prefix for Composable Finance

### DIFF
--- a/chains/v8/chains_dev.json
+++ b/chains/v8/chains_dev.json
@@ -4981,7 +4981,7 @@
             ]
         },
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/Composable.png",
-        "addressPrefix": 49,
+        "addressPrefix": 50,
         "options": [
             "governance-v1"
         ]

--- a/chains/v9/chains_dev.json
+++ b/chains/v9/chains_dev.json
@@ -5026,7 +5026,7 @@
             ]
         },
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/Composable.png",
-        "addressPrefix": 49,
+        "addressPrefix": 50,
         "options": [
             "governance-v1"
         ]


### PR DESCRIPTION
Composable Finance has changed their address prefix to 50.

<img width="600" alt="Screenshot 2023-03-21 at 15 57 41" src="https://user-images.githubusercontent.com/40560660/226613601-dc26d18e-d12d-4d89-aa9c-65df70e89d12.png">
