### PR TITLE
Fix currencyIdScale kBTC-KSM, kBTC-KSM on Kintsugi

### DIFF
--- a/chains/v8/chains_dev.json
+++ b/chains/v8/chains_dev.json
@@ -1720,7 +1720,7 @@
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KBTC-KSM.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x03000b000a",
+                    "currencyIdScale": "0x03000a000b",
                     "currencyIdType": "interbtc_primitives.CurrencyId",
                     "existentialDeposit": "0",
                     "transfersEnabled": true

--- a/chains/v8/chains_dev.json
+++ b/chains/v8/chains_dev.json
@@ -6814,7 +6814,7 @@
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KBTC-KSM.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x03000b000a",
+                    "currencyIdScale": "0x03000a000b",
                     "currencyIdType": "interbtc_primitives.CurrencyId",
                     "existentialDeposit": "0",
                     "transfersEnabled": true
@@ -6827,7 +6827,7 @@
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KBTC-USDT.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x03000b0103000000",
+                    "currencyIdScale": "0x03000b0101000000",
                     "currencyIdType": "interbtc_primitives.CurrencyId",
                     "existentialDeposit": "0",
                     "transfersEnabled": true

--- a/chains/v9/chains_dev.json
+++ b/chains/v9/chains_dev.json
@@ -1720,7 +1720,7 @@
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KBTC-KSM.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x03000b000a",
+                    "currencyIdScale": "0x03000a000b",
                     "currencyIdType": "interbtc_primitives.CurrencyId",
                     "existentialDeposit": "0",
                     "transfersEnabled": true
@@ -6905,7 +6905,7 @@
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KBTC-KSM.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x03000b000a",
+                    "currencyIdScale": "0x03000a000b",
                     "currencyIdType": "interbtc_primitives.CurrencyId",
                     "existentialDeposit": "0",
                     "transfersEnabled": true
@@ -6918,7 +6918,7 @@
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/KBTC-USDT.svg",
                 "typeExtras": {
-                    "currencyIdScale": "0x03000b0103000000",
+                    "currencyIdScale": "0x03000b0101000000",
                     "currencyIdType": "interbtc_primitives.CurrencyId",
                     "existentialDeposit": "0",
                     "transfersEnabled": true


### PR DESCRIPTION
1. `currencyIdScale` for kBTC-KSM on Kintsugi

![image](https://user-images.githubusercontent.com/16337578/227176565-7bb87d6c-bff2-4d3b-9df5-a6e7f2266783.png)

2. no need to change kBTC-USDT on Kintsugi

![image](https://user-images.githubusercontent.com/16337578/227178279-7e072ace-5e65-4ac2-9b05-db125fea6534.png)


3. `currencyIdScale` for kBTC-KSM on Kintsugi Testnet

![image](https://user-images.githubusercontent.com/16337578/227177517-d18a5dc3-502e-4169-80dd-e0bec1c25858.png)

4. `currencyIdScale` for kBTC-USDT on Kintsugi Testnet

![image](https://user-images.githubusercontent.com/16337578/227178110-1dff7a2f-52e2-4763-9761-308c2f5cf9ef.png)

![image](https://user-images.githubusercontent.com/16337578/227177648-937c055a-e021-45ee-b406-2152c01d8920.png)

proofs:
https://t.me/c/1389653279/571
https://t.me/c/1389653279/573