### PR TITLE
fix account for Bifrost Kusama

### DIFF
--- a/tests/chains_for_testBalance.json
+++ b/tests/chains_for_testBalance.json
@@ -42,7 +42,7 @@
     {
         "chainId": "9f28c6a68e0fc9646eff64935684f6eeeece527e37bbe1f213d22caa1d9d6bed",
         "name": "Bifrost",
-        "account": "0x56fb0fa9ad6f278dc92150be9343bf6969d35c0aaa309d61f21ee3006bbf3372"
+        "account": "0xd2f4a1145d6af282a61d8cd8a4d93234232185d07a51f04b43ce593c1e274c2c"
     },
     {
         "chainId": "742a2ca70c2fda6cee4f8df98d64c4c670a052d9568058982dad9d5a7a135c5b",


### PR DESCRIPTION
This PR fix account for balance tests on Bifrost Kusama:
was: https://bifrost-kusama.subscan.io/account/dh1FV8M7uyZdvTUnQKwFLTWP8cVX3VVZzqFdJUGRd4wwSW7
now: https://bifrost-kusama.subscan.io/account/gVZH3zQPWcfdGdqN5vPCJ1reR2Lg3V1tzRoFn3v88XAkoSo