### PR TITLE
Add Proof of Chaos to Kusama OpenGov

### DIFF
--- a/governance/v2/dapps_dev.json
+++ b/governance/v2/dapps_dev.json
@@ -52,9 +52,9 @@
       },
       {
         "title": "Proof of Chaos",
-        "urlV1": "https://www.proofofchaos.app/vote/",
+        "urlV2": "https://www.proofofchaos.app/referenda/{referendumId}",
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/dapps/color/Proof_of_Chaos.png",
-        "details": "Pass the quiz for NFT upgrade"
+        "details": "Vote for NFT"
       }
     ]
   },


### PR DESCRIPTION
* added Proof of Chaos dapp to Kusama OpenGov
* renamed slogan as there is new mechanics:

![image](https://user-images.githubusercontent.com/16337578/230377682-5e8eba93-b174-4a3e-a263-802db30f0ac9.png)
* removed from Kusama Gov1 as:

![image](https://user-images.githubusercontent.com/16337578/230377025-3354a6c2-cb97-4d3b-9c39-8b7486837e26.png)



