### PR TITLE
Update data for testnet

### DIFF
--- a/chains/v10/chains_dev.json
+++ b/chains/v10/chains_dev.json
@@ -6567,14 +6567,14 @@
         ]
     },
     {
-        "chainId": "03e9685133ff74308fc46ac457da098f00d7b0a61498d5cbd7763bf40559fa81",
-        "name": "Novasama Testnet",
+        "chainId": "f460fe68f5f34ced6b18d8e4612410e334c55521bf27714cdca654b63b685ae6",
+        "name": "Novasama Testnet - Kusama",
         "assets": [
             {
                 "assetId": 0,
-                "symbol": "Unit",
-                "precision": 10,
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/GOV2.svg"
+                "symbol": "KSM",
+                "precision": 12,
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Kusama.svg"
             }
         ],
         "nodes": [
@@ -6596,7 +6596,7 @@
             ]
         },
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/Governance2_Testnet.svg",
-        "addressPrefix": 0,
+        "addressPrefix": 2,
         "options": [
             "testnet",
             "governance"

--- a/chains/v11/chains_dev.json
+++ b/chains/v11/chains_dev.json
@@ -6567,14 +6567,14 @@
         ]
     },
     {
-        "chainId": "03e9685133ff74308fc46ac457da098f00d7b0a61498d5cbd7763bf40559fa81",
-        "name": "Novasama Testnet",
+        "chainId": "f460fe68f5f34ced6b18d8e4612410e334c55521bf27714cdca654b63b685ae6",
+        "name": "Novasama Testnet - Kusama",
         "assets": [
             {
                 "assetId": 0,
-                "symbol": "Unit",
-                "precision": 10,
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/GOV2.svg"
+                "symbol": "KSM",
+                "precision": 12,
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Kusama.svg"
             }
         ],
         "nodes": [
@@ -6596,7 +6596,7 @@
             ]
         },
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/Governance2_Testnet.svg",
-        "addressPrefix": 0,
+        "addressPrefix": 2,
         "options": [
             "testnet",
             "governance"

--- a/chains/v9/chains_dev.json
+++ b/chains/v9/chains_dev.json
@@ -6458,14 +6458,14 @@
         ]
     },
     {
-        "chainId": "03e9685133ff74308fc46ac457da098f00d7b0a61498d5cbd7763bf40559fa81",
-        "name": "Novasama Testnet",
+        "chainId": "f460fe68f5f34ced6b18d8e4612410e334c55521bf27714cdca654b63b685ae6",
+        "name": "Novasama Testnet - Kusama",
         "assets": [
             {
                 "assetId": 0,
-                "symbol": "Unit",
-                "precision": 10,
-                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/GOV2.svg"
+                "symbol": "KSM",
+                "precision": 12,
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/white/Kusama.svg"
             }
         ],
         "nodes": [
@@ -6487,7 +6487,7 @@
             ]
         },
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/chains/gradient/Governance2_Testnet.svg",
-        "addressPrefix": 0,
+        "addressPrefix": 2,
         "options": [
             "testnet",
             "governance"


### PR DESCRIPTION
In order to support ParitySigner with our testnet it was regenerated with properties from Kusama.
Spec and .apng file may be found in Omni PR - https://github.com/nova-wallet/omni-enterprise/pull/606#issuecomment-1516517659