### PR TITLE
Fix for getting actual json path

### DIFF
--- a/.github/get_actual_json_path.sh
+++ b/.github/get_actual_json_path.sh
@@ -2,6 +2,21 @@
 SCRIPT_PATH=$(dirname "$0")
 MAIN_DIRECTORY=${SCRIPT_PATH%/*}
 
-folders=($(ls ${MAIN_DIRECTORY}/../$1))
+# Retrieve the folder names and extract the version numbers
+folders=($(ls -1 ${MAIN_DIRECTORY}/../$1))
+version_numbers=()
+for folder in "${folders[@]}"; do
+  # Extract the version number by removing the "v" prefix and any non-numeric characters
+  version_number=$(echo ${folder#v} | tr -dc '[:digit:]')
+  # Append the extracted version number to the array
+  version_numbers+=($version_number)
+done
 
-echo ${folders[-1]}
+# Sort the version numbers in descending order
+sorted_version_numbers=($(printf '%s\n' "${version_numbers[@]}" | sort -rn))
+
+# Retrieve the latest version folder
+latest_version_number=${sorted_version_numbers[0]}
+latest_version_folder="v${latest_version_number}"
+
+echo $latest_version_folder


### PR DESCRIPTION
Transition to v10 lead to problems caused by the directory sorting mechanism on unix systems when we got that order of direcoties:
```bash
README.md apply_dev_to_prod.py chains.json chains_dev.json chains_validator.py chains_validator.yaml types v10 v11 v2 v3 v4 v5 v6 v7 v8 v9
```

That PR fixes it by comparing numbers instead of getting the lates directory.