### PR TITLE
Tests. Fix condition for substrate network selection

### DIFF
--- a/tests/data/setting_data.py
+++ b/tests/data/setting_data.py
@@ -15,8 +15,13 @@ def get_substrate_chains():
         if data.get('name') in skipped_networks:
             continue
         options = data.get('options')
-        if options is None or 'noSubstrateRuntime' in options:
+        
+        if options is None:
             substrate_chains.append(Chain(data))
+        elif 'noSubstrateRuntime' not in options:
+            substrate_chains.append(Chain(data))
+        else:
+            continue
     
     return substrate_chains
 


### PR DESCRIPTION
This PR fixes wrong if condition for selecting Substrate chains.

command:
```bash
python -m pytest --rootdir . --alluredir=allure-results/ -n auto "./tests/test_network_parameters.py" --reruns 1 --reruns-delay 2
```
Result:
<img width="300" alt="Screenshot 2023-04-27 at 12 11 23" src="https://user-images.githubusercontent.com/40560660/234816335-bb8327d9-c318-4d3c-b7a7-30bfca2ee30c.png">

[suites.csv](https://github.com/nova-wallet/nova-utils/files/11341735/suites.csv)

