### PR TITLE
Adding USDT to Pendulum

### DIFF
--- a/chains/v11/chains_dev.json
+++ b/chains/v11/chains_dev.json
@@ -6836,6 +6836,20 @@
                     "existentialDeposit": "1000",
                     "transfersEnabled": true
                 }
+            },
+            {
+                "assetId": 2,
+                "symbol": "USDT",
+                "precision": 10,
+                "priceId": "tether",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0101",
+                    "currencyIdType": "pendulum_runtime.currency.CurrencyId",
+                    "existentialDeposit": "1000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [

--- a/chains/v11/chains_dev.json
+++ b/chains/v11/chains_dev.json
@@ -6840,7 +6840,7 @@
             {
                 "assetId": 2,
                 "symbol": "USDT",
-                "precision": 10,
+                "precision": 6,
                 "priceId": "tether",
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",

--- a/chains/v12/chains_dev.json
+++ b/chains/v12/chains_dev.json
@@ -6880,7 +6880,7 @@
             {
                 "assetId": 2,
                 "symbol": "USDT",
-                "precision": 10,
+                "precision": 6,
                 "priceId": "tether",
                 "type": "orml",
                 "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",

--- a/chains/v12/chains_dev.json
+++ b/chains/v12/chains_dev.json
@@ -6876,6 +6876,20 @@
                     "existentialDeposit": "1000",
                     "transfersEnabled": true
                 }
+            },
+            {
+                "assetId": 2,
+                "symbol": "USDT",
+                "precision": 10,
+                "priceId": "tether",
+                "type": "orml",
+                "icon": "https://raw.githubusercontent.com/nova-wallet/nova-utils/master/icons/tokens/white/USDT.svg",
+                "typeExtras": {
+                    "currencyIdScale": "0x0101",
+                    "currencyIdType": "pendulum_runtime.currency.CurrencyId",
+                    "existentialDeposit": "1000",
+                    "transfersEnabled": true
+                }
             }
         ],
         "nodes": [


### PR DESCRIPTION
This PR adds USDT on Pendulum network:
USDT is XCM(1) on that network, [proof](https://github.com/pendulum-chain/pendulum/blob/44f0d6d46da12810c4cef6b9df3d96620360dc5e/runtime/integration-tests/pendulum/src/tests.rs#L138)
<img width="300" alt="Screenshot 2023-05-25 at 23 04 34" src="https://github.com/nova-wallet/nova-utils/assets/40560660/6059c092-3b13-4279-98c3-6780882bf73e">

so that "currencyIdScale": "0x0101", and ExistentialDeposit is set with [macro](https://github.com/pendulum-chain/pendulum/blob/44f0d6d46da12810c4cef6b9df3d96620360dc5e/runtime/pendulum/src/lib.rs#L675)
